### PR TITLE
1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "1.2.0.dev0"
+version = "1.2.0"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "1.1.5"
+version = "1.2.0.dev0"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 1, 5)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__ = (1, 2, 0)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import utils

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__ = (1, 2, 0)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 
 from . import utils

--- a/src/mapfile_parser/frontends/first_diff.py
+++ b/src/mapfile_parser/frontends/first_diff.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from typing import Callable
 
 from .. import mapfile
 from .. import utils
 
 
-def doFirstDiff(mapPath: Path, expectedMapPath: Path, romPath: Path, expectedRomPath: Path, diffCount: int=5, mismatchSize: bool=False) -> int:
+def doFirstDiff(mapPath: Path, expectedMapPath: Path, romPath: Path, expectedRomPath: Path, diffCount: int=5, mismatchSize: bool=False, bytesConverterCallback:Callable[[bytes, mapfile.MapFile],str|None]|None=None) -> int:
     if not mapPath.exists():
         print(f"{mapPath} must exist")
         return 1
@@ -61,7 +62,14 @@ def doFirstDiff(mapPath: Path, expectedMapPath: Path, romPath: Path, expectedRom
                 if vromInfo is not None:
                     extraMessage = f", {vromInfo.getAsStrPlusOffset()}"
                 print(f"First difference at ROM addr 0x{i:X}{extraMessage}")
-                print(f"Bytes: {utils.hexbytes(builtRom[i : i + 4])} vs {utils.hexbytes(expectedRom[i : i + 4])}")
+                builtBytes = builtRom[i : i + 4]
+                expectedBytes = expectedRom[i : i + 4]
+                print(f"Bytes: {utils.hexbytes(builtBytes)} vs {utils.hexbytes(expectedBytes)}")
+                if bytesConverterCallback is not None:
+                    builtConverted = bytesConverterCallback(builtBytes, builtMapFile)
+                    expectedConverted = bytesConverterCallback(expectedBytes, expectedMapFile)
+                    if builtConverted is not None and expectedConverted is not None:
+                        print(f"{builtConverted} vs {expectedConverted}")
             diffs += 1
 
         if (
@@ -78,7 +86,14 @@ def doFirstDiff(mapPath: Path, expectedMapPath: Path, romPath: Path, expectedRom
                     if vromInfo is not None:
                         extraMessage = f", {vromInfo.getAsStrPlusOffset()}"
                     print(f"Instruction difference at ROM addr 0x{i:X}{extraMessage}")
-                    print(f"Bytes: {utils.hexbytes(builtRom[i : i + 4])} vs {utils.hexbytes(expectedRom[i : i + 4])}")
+                    builtBytes = builtRom[i : i + 4]
+                    expectedBytes = expectedRom[i : i + 4]
+                    print(f"Bytes: {utils.hexbytes(builtBytes)} vs {utils.hexbytes(expectedBytes)}")
+                    if bytesConverterCallback is not None:
+                        builtConverted = bytesConverterCallback(builtBytes, builtMapFile)
+                        expectedConverted = bytesConverterCallback(expectedBytes, expectedMapFile)
+                        if builtConverted is not None and expectedConverted is not None:
+                            print(f"{builtConverted} vs {expectedConverted}")
 
         if len(map_search_diff) >= diffCount and diffs > shift_cap:
             break

--- a/src/mapfile_parser/frontends/first_diff.py
+++ b/src/mapfile_parser/frontends/first_diff.py
@@ -13,7 +13,7 @@ from .. import mapfile
 from .. import utils
 
 
-def doFirstDiff(mapPath: Path, expectedMapPath: Path, romPath: Path, expectedRomPath: Path, diffCount: int=5, mismatchSize: bool=False, bytesConverterCallback:Callable[[bytes, mapfile.MapFile],str|None]|None=None) -> int:
+def doFirstDiff(mapPath: Path, expectedMapPath: Path, romPath: Path, expectedRomPath: Path, diffCount: int=5, mismatchSize: bool=False, addColons: bool=True, bytesConverterCallback:Callable[[bytes, mapfile.MapFile],str|None]|None=None) -> int:
     if not mapPath.exists():
         print(f"{mapPath} must exist")
         return 1
@@ -64,7 +64,7 @@ def doFirstDiff(mapPath: Path, expectedMapPath: Path, romPath: Path, expectedRom
                 print(f"First difference at ROM addr 0x{i:X}{extraMessage}")
                 builtBytes = builtRom[i : i + 4]
                 expectedBytes = expectedRom[i : i + 4]
-                print(f"Bytes: {utils.hexbytes(builtBytes)} vs {utils.hexbytes(expectedBytes)}")
+                print(f"Bytes: {utils.hexbytes(builtBytes, addColons=addColons)} vs {utils.hexbytes(expectedBytes, addColons=addColons)}")
                 if bytesConverterCallback is not None:
                     builtConverted = bytesConverterCallback(builtBytes, builtMapFile)
                     expectedConverted = bytesConverterCallback(expectedBytes, expectedMapFile)
@@ -88,7 +88,7 @@ def doFirstDiff(mapPath: Path, expectedMapPath: Path, romPath: Path, expectedRom
                     print(f"Instruction difference at ROM addr 0x{i:X}{extraMessage}")
                     builtBytes = builtRom[i : i + 4]
                     expectedBytes = expectedRom[i : i + 4]
-                    print(f"Bytes: {utils.hexbytes(builtBytes)} vs {utils.hexbytes(expectedBytes)}")
+                    print(f"Bytes: {utils.hexbytes(builtBytes, addColons=addColons)} vs {utils.hexbytes(expectedBytes, addColons=addColons)}")
                     if bytesConverterCallback is not None:
                         builtConverted = bytesConverterCallback(builtBytes, builtMapFile)
                         expectedConverted = bytesConverterCallback(expectedBytes, expectedMapFile)

--- a/src/mapfile_parser/utils.py
+++ b/src/mapfile_parser/utils.py
@@ -26,8 +26,11 @@ def readFileAsBytearray(filepath: Path) -> bytearray:
     with filepath.open(mode="rb") as f:
         return bytearray(f.read())
 
-def hexbytes(bs: bytes) -> str:
-    return ":".join("{:02X}".format(c) for c in bs)
+def hexbytes(bs: bytes, addColons: bool=True) -> str:
+    glue = ""
+    if addColons:
+        glue = ""
+    return glue.join("{:02X}".format(c) for c in bs)
 
 def getGitCommitTimestamp() -> int:
     return int(subprocess.check_output(['git', 'show', '-s', '--format=%ct']).decode('ascii').rstrip())

--- a/src/mapfile_parser/utils.py
+++ b/src/mapfile_parser/utils.py
@@ -26,7 +26,7 @@ def readFileAsBytearray(filepath: Path) -> bytearray:
     with filepath.open(mode="rb") as f:
         return bytearray(f.read())
 
-def hexbytes(bs):
+def hexbytes(bs: bytes) -> str:
     return ":".join("{:02X}".format(c) for c in bs)
 
 def getGitCommitTimestamp() -> int:


### PR DESCRIPTION
- `first_diff` frontend:
  - Allow an optional bytes converter callback. It can be useful to perform analysis or instruction decoding on the caller side.
  - Parameter to toggle colons (`:`) in bytes difference output