### PR TITLE
1.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "1.2.0"
+version = "1.2.1"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 2, 0)
+__version_info__ = (1, 2, 1)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 

--- a/src/mapfile_parser/utils.py
+++ b/src/mapfile_parser/utils.py
@@ -29,7 +29,7 @@ def readFileAsBytearray(filepath: Path) -> bytearray:
 def hexbytes(bs: bytes, addColons: bool=True) -> str:
     glue = ""
     if addColons:
-        glue = ""
+        glue = ":"
     return glue.join("{:02X}".format(c) for c in bs)
 
 def getGitCommitTimestamp() -> int:


### PR DESCRIPTION
- Fix missing `:` colon even when passing `addColons=True` to the first_diff frontend