### PR TITLE
2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The list can be checked in runtime with `python3 -m mapfile_parser --help`.
 Each one of them can be executed with `python3 -m mapfile_parser utilityname`, for example `python3 -m mapfile_parser pj64_syms`.
 
 - `first_diff`: Find the first difference(s) between the built ROM and the base ROM.
+- `jsonify`: Converts a mapfile into a json format.
 - `pj64_syms`: Produce a PJ64 compatible symbol map.
 - `progress`: Computes current progress of the matched functions. Relies on a [splat](https://github.com/ethteck/splat) folder structure and matched functions not longer having a file.
 - `sym_info`: Display various information about a symbol or address.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "2.0.0.dev0"
+version = "2.0.0"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 [project]
 name = "mapfile_parser"
-version = "1.2.1"
+version = "1.2.2.dev0"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "1.3.0.dev0"
+version = "2.0.0.dev0"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "1.2.2.dev0"
+version = "1.3.0.dev0"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
 
-__version_info__ = (1, 2, 1)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__ = (1, 2, 2)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import utils

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__ = (2, 0, 0)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 
 from . import utils as utils

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -14,6 +14,7 @@ from . import utils as utils
 from .mapfile import MapFile as MapFile
 from .mapfile import Symbol as Symbol
 from .mapfile import File as File
+from .mapfile import Segment as Segment
 from .mapfile import FoundSymbolInfo as FoundSymbolInfo
 
 from .progress_stats import ProgressStats as ProgressStats

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 3, 0)
+__version_info__ = (2, 0, 0)
 __version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -5,15 +5,17 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 2, 2)
+__version_info__ = (1, 3, 0)
 __version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
-from . import utils
+from . import utils as utils
 
-from .mapfile import MapFile
-from .mapfile import Symbol, File, FoundSymbolInfo
+from .mapfile import MapFile as MapFile
+from .mapfile import Symbol as Symbol
+from .mapfile import File as File
+from .mapfile import FoundSymbolInfo as FoundSymbolInfo
 
-from .progress_stats import ProgressStats
+from .progress_stats import ProgressStats as ProgressStats
 
-from . import frontends
+from . import frontends as frontends

--- a/src/mapfile_parser/__main__.py
+++ b/src/mapfile_parser/__main__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/src/mapfile_parser/__main__.py
+++ b/src/mapfile_parser/__main__.py
@@ -16,6 +16,7 @@ def mapfileParserMain():
     subparsers = parser.add_subparsers(description="action", help="the action to perform", required=True)
 
     mapfile_parser.frontends.first_diff.addSubparser(subparsers)
+    mapfile_parser.frontends.jsonify.addSubparser(subparsers)
     mapfile_parser.frontends.pj64_syms.addSubparser(subparsers)
     mapfile_parser.frontends.progress.addSubparser(subparsers)
     mapfile_parser.frontends.sym_info.addSubparser(subparsers)

--- a/src/mapfile_parser/frontends/__init__.py
+++ b/src/mapfile_parser/frontends/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/src/mapfile_parser/frontends/__init__.py
+++ b/src/mapfile_parser/frontends/__init__.py
@@ -6,9 +6,10 @@
 from __future__ import annotations
 
 
-from . import first_diff
-from . import pj64_syms
-from . import progress
-from . import sym_info
-from . import symbol_sizes_csv
-from . import upload_frogress
+from . import first_diff as first_diff
+from . import jsonify as jsonify
+from . import pj64_syms as pj64_syms
+from . import progress as progress
+from . import sym_info as sym_info
+from . import symbol_sizes_csv as symbol_sizes_csv
+from . import upload_frogress as upload_frogress

--- a/src/mapfile_parser/frontends/first_diff.py
+++ b/src/mapfile_parser/frontends/first_diff.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/src/mapfile_parser/frontends/jsonify.py
+++ b/src/mapfile_parser/frontends/jsonify.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .. import mapfile
+
+
+def doJsonify(mapPath: Path, outputPath: Path|None) -> int:
+    mapFile = mapfile.MapFile()
+    mapFile.readMapFile(mapPath)
+
+    jsonStr = json.dumps(mapFile.toJson(), indent=4)
+
+    if outputPath is None:
+        print(jsonStr)
+    else:
+        outputPath.parent.mkdir(parents=True, exist_ok=True)
+        outputPath.write_text(jsonStr)
+
+    return 0
+
+
+def processArguments(args: argparse.Namespace):
+    mapPath: Path = args.mapfile
+    outputPath: Path|None = Path(args.output) if args.output is not None else None
+
+    exit(doJsonify(mapPath, outputPath))
+
+def addSubparser(subparser: argparse._SubParsersAction[argparse.ArgumentParser]):
+    parser = subparser.add_parser("jsonify", help="Converts a mapfile into a json format.")
+
+    parser.add_argument("mapfile", help="Path to a map file", type=Path)
+    parser.add_argument("-o", "--output", help="Output path of for the generated json. If omitted then stdout is used instead.")
+
+    parser.set_defaults(func=processArguments)

--- a/src/mapfile_parser/frontends/pj64_syms.py
+++ b/src/mapfile_parser/frontends/pj64_syms.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/src/mapfile_parser/frontends/pj64_syms.py
+++ b/src/mapfile_parser/frontends/pj64_syms.py
@@ -14,10 +14,11 @@ from .. import mapfile
 
 
 def writePj64SymsToFile(mapFile: mapfile.MapFile, outFile: TextIO):
-    for file in mapFile:
-        for sym in file:
-            symType = "code" if file.segmentType == ".text" else "data"
-            outFile.write(f"{sym.vram:08X},{symType},{sym.name}\n")
+    for segment in mapFile:
+        for file in segment:
+            for sym in file:
+                symType = "code" if file.sectionType == ".text" else "data"
+                outFile.write(f"{sym.vram:08X},{symType},{sym.name}\n")
 
 def doPj64Syms(mapPath: Path, outputPath: Path|None) -> int:
     mapFile = mapfile.MapFile()

--- a/src/mapfile_parser/frontends/progress.py
+++ b/src/mapfile_parser/frontends/progress.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/src/mapfile_parser/frontends/progress.py
+++ b/src/mapfile_parser/frontends/progress.py
@@ -18,7 +18,7 @@ def getProgress(mapPath: Path, asmPath: Path, nonmatchingsPath: Path, pathIndex:
     mapFile.debugging = debugging
     mapFile.readMapFile(mapPath)
 
-    return mapFile.filterBySegmentType(".text").getProgress(asmPath, nonmatchingsPath, pathIndex=pathIndex)
+    return mapFile.filterBySectionType(".text").getProgress(asmPath, nonmatchingsPath, pathIndex=pathIndex)
 
 def doProgress(mapPath: Path, asmPath: Path, nonmatchingsPath: Path, pathIndex: int=2, debugging: bool=False) -> int:
     totalStats, progressPerFolder = getProgress(mapPath, asmPath, nonmatchingsPath, pathIndex=pathIndex, debugging=debugging)

--- a/src/mapfile_parser/frontends/sym_info.py
+++ b/src/mapfile_parser/frontends/sym_info.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/src/mapfile_parser/frontends/symbol_sizes_csv.py
+++ b/src/mapfile_parser/frontends/symbol_sizes_csv.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/src/mapfile_parser/frontends/symbol_sizes_csv.py
+++ b/src/mapfile_parser/frontends/symbol_sizes_csv.py
@@ -15,7 +15,7 @@ def processArguments(args: argparse.Namespace):
     mapFile = mapfile.MapFile()
     mapFile.readMapFile(args.mapfile)
     if args.filter_section is not None:
-        mapFile = mapFile.filterBySegmentType(args.filter_section)
+        mapFile = mapFile.filterBySectionType(args.filter_section)
 
     if args.same_folder:
         mapFile = mapFile.mixFolders()

--- a/src/mapfile_parser/frontends/upload_frogress.py
+++ b/src/mapfile_parser/frontends/upload_frogress.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/src/mapfile_parser/mapfile.py
+++ b/src/mapfile_parser/mapfile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/src/mapfile_parser/progress_stats.py
+++ b/src/mapfile_parser/progress_stats.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/src/mapfile_parser/utils.py
+++ b/src/mapfile_parser/utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations


### PR DESCRIPTION
- Change logic of `MapFile` so it can parse and organize each file in proper segments.
  - This breaks old ways of iterating the `MapFile` class. Now iterating it yields a `Segment`, iterating it yields a `File`.
- `toJson` method which allow serializing map files into the json format.
- `jsonify` frontend which allows converting a mapfile into a json format from the CLI.
- Rename `segmentType` to `sectionType` and `filterBySegmentType` to `filterBySectionType`.