### PR TITLE
2.1.5

### DIFF
--- a/.github/workflows/md_lint.yml
+++ b/.github/workflows/md_lint.yml
@@ -1,0 +1,17 @@
+name: Lint markdown files
+
+# Build on every branch push, tag push, and pull request change:
+on: [push, pull_request]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    name: Lint md files
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Lint markdown files
+      uses: articulate/actions-markdownlint@v1.1.0
+      with:
+        config: .markdownlint.jsonc

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: mypy
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install local mapfile_parser
       run: pip install .

--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install build module
         run: pip install build

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,14 @@
+{
+    // https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md
+    // MD024 - Multiple headings with the same content
+    "MD024": {
+        "siblings_only": true
+    },
+
+    // https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md
+    // MD013 - Line length
+    "MD013": {
+        "code_block_line_length": 120,
+        "headings": false
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.5] - 2023-10-02
+
 ### Added
 
 - Add `CHANGELOG.md`
@@ -15,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Cleanup the `README.md` a bit
+- Update Github Action's dependencies
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,216 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add `CHANGELOG.md`
+
+## [2.1.4] - 2023-09-11
+
+### Fixed
+
+- Fix vrom calculation if the first symbol of a file is not available in the
+  map file
+
+## [1.3.2] - 2023-09-11
+
+### Added
+
+- Add version info to the cli
+- Add small testing suite
+- Add machine-friendly/non-human-readable option for json generation.
+  - Numbers are outputted as real numbers instead of prettified strings
+
+### Changed
+
+- Allow csv conversion to be written to a file instead of only printing to stdout
+- Output `none` instead of `"None"` for symbols with no vrom when generating
+  json output.
+
+### Fixed
+
+- Fix vrom calculation if the first symbol of a file is not available in the
+  map file
+
+Full changes: <https://github.com/Decompollaborate/mapfile_parser/compare/702a73452059ce4e97cda011e09dc4ef2a7b9dec...ba444b0bbfdfad7fb07347bf656b7fd4381596fb>
+
+## [2.1.3] - 2023-08-30
+
+### Fixed
+
+- Fix version number
+  - pypi thought previous version was a prerelease instead of a full release
+
+## [2.1.2] - 2023-08-30
+
+### Added
+
+- Add machine-friendly/non-human-readable option for json generation.
+  - Numbers are outputted as real numbers instead of prettified strings
+- Add some CI tests
+
+### Changed
+
+- Output `none` instead of `"None"` for symbols with no vrom when generating
+  json output.
+- Make dummy files for `*fill*` lines instead of adding them to the previous file.
+- Don't drop the dummy segment if it actually has data on it
+
+## [2.1.1] - 2023-08-15
+
+### Fixed
+
+- Fix off-by-one issue which was throwing away tons of data
+
+## [2.1.0] - 2023-08-14
+
+### Added
+
+- Add `bss_check` frontend
+  - Allows to search for reordered bss variables by comparing two map files.
+
+### Changed
+
+- Don't skip important lines in some kinds of map files.
+  - This may produce map parsing to be a bit slower but it should work properly
+    with more kinds of mapfiles
+
+### Fixed
+
+- Try to prevent crashes if a file is found before the first segment is found
+
+## [2.0.1] - 2023-08-07
+
+### Changed
+
+- Makes `Symbol`, `File` and `Segment` hashable
+
+## [1.3.1] - 2023-08-06
+
+### Changed
+
+- Make `Symbol` and `File` types hashable
+
+## [2.0.0] - 2023-08-01
+
+### Added
+
+- `toJson` method which allow serializing map files into the json format.
+- `jsonify` frontend which allows converting a mapfile into a json format from
+  the CLI.
+
+### Changed
+
+- Change logic of `MapFile` so it can parse and organize each file in proper
+  segments.
+  - This breaks old ways of iterating the `MapFile` class. Now iterating it
+    yields a `Segment`, iterating that yields a `File`.
+- Rename `segmentType` to `sectionType` and `filterBySegmentType` to
+  `filterBySectionType`.
+
+## [1.3.0] - 2023-08-01
+
+### Added
+
+- Add function `toJson` to export map file as a json. It returns a `dict`.
+- New `jsonify` frontend, which allows converting a map file in the cli.
+
+## [1.2.1] - 2023-07-28
+
+### Fixed
+
+- Fix missing `:` colon even when passing `addColons=True` to the `first_diff`
+  frontend
+
+## [1.2.0] - 2023-07-28
+
+### Added
+
+- `first_diff` frontend:
+  - Allow an optional bytes converter callback. It can be useful to perform
+    analysis or instruction decoding on the caller side.
+  - Parameter to toggle colons (`:`) in bytes difference output
+
+## [1.1.5] - 2023-07-28
+
+### Fixed
+
+- Fix map parsing ignoring some `*fill*` entries
+- Improve symbol info output a bit
+
+## [1.1.4] - 2023-04-03
+
+### Fixed
+
+- Add missing `request` requirement
+
+## [1.1.3] - 2023-02-22
+
+### Added
+
+- Add flag to enable debug prints
+- Add flag to specify the path index
+
+### Fixed
+
+- Properly handle files with multiple extensions
+
+## [1.1.2] - 2022-12-14
+
+### Changed
+
+- Modularize `upload_frogress` frontend
+
+## [1.1.1] - 2022-12-14
+
+### Added
+
+- Add examples to README
+
+## [1.1.0] - 2022-12-14
+
+### Added
+
+- Compute vrom addresses of symbols and files
+- Provide various front-ends clis (see README for more info):
+  - `first_diff`
+  - `pj64_syms`
+  - `progress`
+  - `sym_info`
+  - `symbol_sizes_csv`
+  - `upload_frogress`
+
+[Full changelog](https://github.com/Decompollaborate/mapfile_parser/compare/1.0.0...1.1.0)
+
+## [1.0.0] - 2022-12-13
+
+### Added
+
+- Initial release
+
+[unreleased]: https://github.com/Decompollaborate/mapfile_parser/compare/master...develop
+[2.1.4]: https://github.com/Decompollaborate/mapfile_parser/compare/1.3.2...2.1.4
+[1.3.2]: https://github.com/Decompollaborate/mapfile_parser/compare/2.1.3...1.3.2
+[2.1.3]: https://github.com/Decompollaborate/mapfile_parser/compare/2.1.2...2.1.3
+[2.1.2]: https://github.com/Decompollaborate/mapfile_parser/compare/2.1.1...2.1.2
+[2.1.1]: https://github.com/Decompollaborate/mapfile_parser/compare/2.1.0...2.1.1
+[2.1.0]: https://github.com/Decompollaborate/mapfile_parser/compare/2.0.1...2.1.0
+[2.0.1]: https://github.com/Decompollaborate/mapfile_parser/compare/1.3.1...2.0.1
+[1.3.1]: https://github.com/Decompollaborate/mapfile_parser/compare/2.0.0...1.3.1
+[2.0.0]: https://github.com/Decompollaborate/mapfile_parser/compare/1.3.0...2.0.0
+[1.3.0]: https://github.com/Decompollaborate/mapfile_parser/compare/1.2.1...1.3.0
+[1.2.1]: https://github.com/Decompollaborate/mapfile_parser/compare/1.2.0...1.2.1
+[1.2.0]: https://github.com/Decompollaborate/mapfile_parser/compare/1.1.5...1.2.0
+[1.1.5]: https://github.com/Decompollaborate/mapfile_parser/compare/1.1.4...1.1.5
+[1.1.4]: https://github.com/Decompollaborate/mapfile_parser/compare/1.1.3...1.1.4
+[1.1.3]: https://github.com/Decompollaborate/mapfile_parser/compare/1.1.2...1.1.3
+[1.1.2]: https://github.com/Decompollaborate/mapfile_parser/compare/1.1.1...1.1.2
+[1.1.1]: https://github.com/Decompollaborate/mapfile_parser/compare/1.1.0...1.1.1
+[1.1.0]: https://github.com/Decompollaborate/mapfile_parser/compare/1.0.0...1.1.0
+[1.0.0]: https://github.com/Decompollaborate/mapfile_parser/releases/tag/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cleanup the `README.md` a bit
 
+### Deprecated
+
+- Deprecate `File.getName`
+  - The method itself doesn't make sense, instead operate on `File.filepath` directly
+- Deprecate `MapFile.debugging`
+- Deprecate `progress` frontend's `--debugging` flag
+
 ## [2.1.4] - 2023-09-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `CHANGELOG.md`
+- Add markdown linter to CI
+
+### Changed
+
+- Cleanup the `README.md` a bit
 
 ## [2.1.4] - 2023-09-11
 

--- a/README.md
+++ b/README.md
@@ -13,33 +13,77 @@ Map file parser library focusing decompilation projects.
 The recommended way to install is using from the PyPi release, via `pip`:
 
 ```bash
-pip install mapfile-parser
+pip install mapfile_parser
 ```
 
-In case you want to mess with the latest development version without wanting to clone the repository, then you could use the following command:
+If you use a `requirements.txt` file in your repository, then you can add
+this library with the following line:
+
+```txt
+mapfile_parser>=2.1.5,<3.0.0
+```
+
+### Development version
+
+The unstable development version is located at the [develop](https://github.com/Decompollaborate/mapfile_parser/tree/develop)
+branch. PRs should be made into that branch instead of the main one.
+
+The recommended way to install a locally cloned repo is by passing the `-e`
+(editable) flag to `pip`.
 
 ```bash
-pip uninstall mapfile-parser
+python3 -m pip install -e .
+```
+
+In case you want to mess with the latest development version without wanting to
+clone the repository, then you could use the following command:
+
+```bash
+pip uninstall mapfile_parser
 pip install git+https://github.com/Decompollaborate/mapfile_parser.git@develop
 ```
 
-NOTE: Installing the development version is not recommended. Proceed at your own risk.
+NOTE: Installing the development version is not recommended unless you know what
+you are doing. Proceed at your own risk.
+
+## Versioning and changelog
+
+This library follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+We try to always keep backwards compatibility, so no breaking changes should
+happen until a major release (i.e. jumping from 2.X.X to 3.0.0).
+
+To see what changed on each release check either the [CHANGELOG.md](CHANGELOG.md)
+file or check the [releases page on Github](https://github.com/Decompollaborate/mapfile_parser/releases).
+You can also use [this link](https://github.com/Decompollaborate/mapfile_parser/releases/latest)
+to check the latest release.
 
 ## Examples
 
-Various cli examples are provided in the [frontends folder](src/mapfile_parser/frontends). Most of them are re-implementations of already existing tools using this library to show how to use this library and inspire new ideas.
+Various cli examples are provided in the [frontends folder](src/mapfile_parser/frontends).
+Most of them are re-implementations of already existing tools using this
+library to show how to use this library and inspire new ideas.
 
 The list can be checked in runtime with `python3 -m mapfile_parser --help`.
 
-Each one of them can be executed with `python3 -m mapfile_parser utilityname`, for example `python3 -m mapfile_parser pj64_syms`.
+Each one of them can be executed with `python3 -m mapfile_parser utilityname`,
+for example `python3 -m mapfile_parser pj64_syms`.
 
 - `bss_check`: Check that globally visible bss has not been reordered.
-- `first_diff`: Find the first difference(s) between the built ROM and the base ROM.
+- `first_diff`: Find the first difference(s) between the built ROM and the base
+  ROM.
 - `jsonify`: Converts a mapfile into a json format.
 - `pj64_syms`: Produce a PJ64 compatible symbol map.
-- `progress`: Computes current progress of the matched functions. Relies on a [splat](https://github.com/ethteck/splat) folder structure and matched functions not longer having a file.
+- `progress`: Computes current progress of the matched functions. Relies on a
+  [splat](https://github.com/ethteck/splat) folder structure and each matched
+  functions no longer having an `.s` file (i.e: delete the file after matching it).
 - `sym_info`: Display various information about a symbol or address.
-- `symbol_sizes_csv`: Produces a csv summarizing the files sizes by parsing a map file.
-- `upload_frogress`: Uploads current progress (calculated by the `progress` utility) of the matched functions to [frogress](https://github.com/decompals/frogress).
+- `symbol_sizes_csv`: Produces a csv summarizing the files sizes by parsing a
+  map file.
+- `upload_frogress`: Uploads current progress (calculated by the `progress`
+  utility) of the matched functions to [frogress](https://github.com/decompals/frogress).
 
-None of the provided cli utilities are meant to be used directly on a command line, because they need a large number of long parameters to them and every repo has their own quirks which would need them to be adapted. Those have been written mostly to facilitate people to write those utilities in a way which accomodates their own repo.
+None of the provided cli utilities are meant to be used directly on a command
+line, because they need a large number of long parameters to them and every repo
+has their own quirks which would need them to be adapted. Those have been
+written mostly to facilitate people to write those utilities in a way which
+accomodates their own repo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "2.1.4"
+version = "2.1.5.dev0"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "2.1.5.dev0"
+version = "2.1.5"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__ = (2, 1, 5)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 
 from . import utils as utils

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (2, 1, 4)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__ = (2, 1, 5)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import utils as utils

--- a/src/mapfile_parser/mapfile.py
+++ b/src/mapfile_parser/mapfile.py
@@ -165,6 +165,7 @@ class File:
         return self.vrom
 
 
+    #! @deprecated
     def getName(self) -> Path:
         return Path(*self.filepath.with_suffix("").parts[2:])
 
@@ -445,6 +446,8 @@ class Segment:
 class MapFile:
     def __init__(self):
         self._segmentsList: list[Segment] = list()
+
+        #! @deprecated
         self.debugging: bool = False
 
     def readMapFile(self, mapPath: Path):


### PR DESCRIPTION
## [2.1.5] - 2023-10-02

### Added

- Add `CHANGELOG.md`
- Add markdown linter to CI

### Changed

- Cleanup the `README.md` a bit
- Update Github Action's dependencies

### Deprecated

- Deprecate `File.getName`
  - The method itself doesn't make sense, instead operate on `File.filepath` directly
- Deprecate `MapFile.debugging`
- Deprecate `progress` frontend's `--debugging` flag
