### PR TITLE
2.2.1

### DIFF
--- a/.github/workflows/maturin_upload_pypi.yml
+++ b/.github/workflows/maturin_upload_pypi.yml
@@ -3,7 +3,7 @@
 #
 #    maturin generate-ci github
 #
-name: CI
+name: Upload to PyPI
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2023-10-08
+
 ### Fixed
 
 - Fix Rust crate size being too big
@@ -236,6 +238,7 @@ Full changes: <https://github.com/Decompollaborate/mapfile_parser/compare/702a73
 - Initial release
 
 [unreleased]: https://github.com/Decompollaborate/mapfile_parser/compare/master...develop
+[2.2.1]: https://github.com/Decompollaborate/mapfile_parser/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/Decompollaborate/mapfile_parser/compare/2.1.5...2.2.0
 [2.1.5]: https://github.com/Decompollaborate/mapfile_parser/compare/2.1.4...2.1.5
 [2.1.4]: https://github.com/Decompollaborate/mapfile_parser/compare/2.1.3...2.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Rust crate size being too big
+  - crates.io was rejecting the package because of the size
+  - Cargo was packaging all the map files and test cases, making the package be
+    15 MiB. Now it is around 16.3 KiB
+
 ## [2.2.0] - 2023-10-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "mapfile_parser"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 authors = ["Anghelo Carvajal <angheloalf95@gmail.com>"]
 description = "Map file parser library focusing decompilation projects"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 authors = ["Anghelo Carvajal <angheloalf95@gmail.com>"]
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
+homepage = "https://github.com/Decompollaborate/mapfile_parser"
+repository = "https://github.com/Decompollaborate/mapfile_parser"
 license = "MIT"
 keywords = ["mapfile", "parser", "decomp", "decompilation"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/Decompollaborate/mapfile_parser"
 repository = "https://github.com/Decompollaborate/mapfile_parser"
 license = "MIT"
 keywords = ["mapfile", "parser", "decomp", "decompilation"]
+exclude = ["tests/output", "*.py", "*.pyi", ".github", ".markdownlint.jsonc", "mypy.ini", "requirements.txt", "pyproject.toml", "tests"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "2.2.0"
+version = "2.2.1.dev0"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "2.2.1.dev0"
+version = "2.2.1"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (2, 2, 0)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__ = (2, 2, 1)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import utils as utils

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__ = (2, 2, 1)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 
 from . import utils as utils


### PR DESCRIPTION
### Fixed

- Fix Rust crate size being too big
  - crates.io was rejecting the package because of the size
  - Cargo was packaging all the map files and test cases, making the package be
    15 MiB. Now it is around 16.3 KiB
