### PR TITLE
Remove `pyo3` hard requirement

### DIFF
--- a/.github/workflows/maturin_upload_pypi.yml
+++ b/.github/workflows/maturin_upload_pypi.yml
@@ -98,7 +98,7 @@ jobs:
           path: dist
 
   check_clippy_python_bindings:
-    name: Check clippy for C bindings
+    name: Check clippy for Python bindings
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/maturin_upload_pypi.yml
+++ b/.github/workflows/maturin_upload_pypi.yml
@@ -7,11 +7,6 @@ name: Upload to PyPI
 
 on:
   push:
-    branches:
-      - main
-      - master
-    tags:
-      - '*'
   pull_request:
   workflow_dispatch:
 
@@ -102,11 +97,31 @@ jobs:
           name: wheels
           path: dist
 
+  check_clippy_python_bindings:
+    name: Check clippy for C bindings
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout reposistory
+      uses: actions/checkout@v4
+
+    - name: Setup Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
+    - name: Setup clippy
+      run: rustup component add clippy
+
+    - name: Run clippy
+      run: cargo clippy --all-targets --features python_bindings -- -D warnings
+
   release:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [linux, windows, macos, sdist]
+    needs: [linux, windows, macos, sdist, check_clippy_python_bindings]
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/publish_crate.yml
+++ b/.github/workflows/publish_crate.yml
@@ -4,8 +4,8 @@ name: Build and upload Rust crate
 on: [push, pull_request]
 
 jobs:
-  build_rust:
-    name: Build Rust stuff and run Rust tests
+  check_fmt:
+    name: Check format
     runs-on: ubuntu-latest
 
     steps:
@@ -21,17 +21,59 @@ jobs:
     - name: Check format
       run: cargo fmt --check
 
+  check_clippy:
+    name: Check clippy
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout reposistory
+      uses: actions/checkout@v4
+
+    - name: Setup Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
     - name: Setup clippy
       run: rustup component add clippy
 
     - name: Run clippy
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      run: cargo clippy --all-targets -- -D warnings
+
+  run_tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout reposistory
+      uses: actions/checkout@v4
+
+    - name: Setup Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
+    - name: Run tests
+      run: cargo test --workspace
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout reposistory
+      uses: actions/checkout@v4
+
+    - name: Setup Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
 
     - name: Build Rust package
       run: cargo build --release --workspace
-
-    - name: Build Rust tests
-      run: cargo test --workspace
 
     - name: Publish dry run
       if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `pyo3` is no longer needed to use this crate as Rust-only library.
+
 ## [2.3.0] - 2023-11-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 regex = "1.9.5"
-# pyo3 = { version = "0.19.0", optional = true }
-pyo3 = { version = "0.19.0", optional = false }
+pyo3 = { version = "0.19.0", optional = true }
 lazy_static = "1.4.0"
 
 [features]
-python_bindings = []
-# python_bindings = ["dep:pyo3"]
+# python_bindings will be removed from the default in the future
+default = ["python_bindings"]
+python_bindings = ["dep:pyo3"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,8 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 regex = "1.9.5"
-# pyo3 = { version = "0.19.0", optional = true }
-pyo3 = { version = "0.19.0", optional = false }
+pyo3 = { version = "0.19.0", optional = true }
 lazy_static = "1.4.0"
 
 [features]
-# python_bindings = ["dep:pyo3"]
-python_bindings = []
+python_bindings = ["dep:pyo3"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 regex = "1.9.5"
-pyo3 = { version = "0.19.0", optional = true }
+# pyo3 = { version = "0.19.0", optional = true }
+pyo3 = { version = "0.19.0", optional = false }
 lazy_static = "1.4.0"
 
 [features]
-# python_bindings will be removed from the default in the future
-default = ["python_bindings"]
-python_bindings = ["dep:pyo3"]
+# python_bindings = ["dep:pyo3"]
+python_bindings = []

--- a/src/mapfile_parser/frontends/progress.py
+++ b/src/mapfile_parser/frontends/progress.py
@@ -32,7 +32,7 @@ def processArguments(args: argparse.Namespace):
     asmPath: Path = args.asmpath
     nonmatchingsPath: Path = args.nonmatchingspath
     pathIndex: int = args.path_index
-    debugging: bool = args.debugging
+    debugging: bool = args.debugging #! @deprecated
 
     exit(doProgress(mapPath, asmPath, nonmatchingsPath, pathIndex=pathIndex, debugging=debugging))
 
@@ -43,6 +43,6 @@ def addSubparser(subparser: argparse._SubParsersAction[argparse.ArgumentParser])
     parser.add_argument("asmpath", help="Path to asm folder", type=Path)
     parser.add_argument("nonmatchingspath", help="Path to nonmatchings folder", type=Path)
     parser.add_argument("-i", "--path-index", help="Specify the index to start reading the file paths. Defaults to 2", type=int, default=2)
-    parser.add_argument("-d", "--debugging", help="Enable debugging prints", action="store_true")
+    parser.add_argument("-d", "--debugging", help="Enable debugging prints. This option is deprecated", action="store_true")
 
     parser.set_defaults(func=processArguments)

--- a/src/rs/file.rs
+++ b/src/rs/file.rs
@@ -280,14 +280,7 @@ pub(crate) mod python_bindings {
             vrom: Option<u64>,
             align: Option<u64>,
         ) -> Self {
-            Self::new(
-                filepath,
-                vram,
-                size,
-                section_type,
-                vrom,
-                align,
-            )
+            Self::new(filepath, vram, size, section_type, vrom, align)
         }
 
         /* Getters and setters */

--- a/src/rs/found_symbol_info.rs
+++ b/src/rs/found_symbol_info.rs
@@ -75,11 +75,7 @@ pub(crate) mod python_bindings {
         #[new]
         #[pyo3(signature=(file, symbol, offset=0))]
         pub fn py_new(file: file::File, symbol: symbol::Symbol, offset: i64) -> Self {
-            Self::new (
-                file,
-                symbol,
-                offset,
-            )
+            Self::new(file, symbol, offset)
         }
 
         /* Getters and setters */

--- a/src/rs/found_symbol_info.rs
+++ b/src/rs/found_symbol_info.rs
@@ -4,34 +4,36 @@
 use crate::{file, symbol};
 use std::fmt::Write;
 
+#[cfg(feature = "python_bindings")]
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(module = "mapfile_parser")]
+#[cfg_attr(feature = "python_bindings", pyclass(module = "mapfile_parser"))]
 pub struct FoundSymbolInfo {
-    #[pyo3(get, set)]
     pub file: file::File,
 
-    #[pyo3(get, set)]
     pub symbol: symbol::Symbol,
 
-    #[pyo3(get, set)]
     pub offset: i64,
 }
 
-#[pymethods]
 impl FoundSymbolInfo {
-    #[new]
-    #[pyo3(signature=(file, symbol, offset=0))]
     pub fn new(file: file::File, symbol: symbol::Symbol, offset: i64) -> Self {
-        FoundSymbolInfo {
+        Self {
             file,
             symbol,
             offset,
         }
     }
 
-    #[pyo3(name = "getAsStr")]
+    pub fn new_default(file: file::File, symbol: symbol::Symbol) -> Self {
+        Self {
+            file,
+            symbol,
+            offset: 0,
+        }
+    }
+
     pub fn get_as_str(&self) -> String {
         format!(
             "'{0}' (VRAM: {1}, VROM: {2}, SIZE: {3}, {4})",
@@ -43,7 +45,6 @@ impl FoundSymbolInfo {
         )
     }
 
-    #[pyo3(name = "getAsStrPlusOffset")]
     pub fn get_as_str_plus_offset(&self, sym_name: Option<String>) -> String {
         let mut message;
 
@@ -62,12 +63,70 @@ impl FoundSymbolInfo {
     }
 }
 
-impl FoundSymbolInfo {
-    pub fn new_default(file: file::File, symbol: symbol::Symbol) -> Self {
-        FoundSymbolInfo {
-            file,
-            symbol,
-            offset: 0,
+#[cfg(feature = "python_bindings")]
+#[allow(non_snake_case)]
+pub(crate) mod python_bindings {
+    use pyo3::prelude::*;
+
+    use crate::{file, symbol};
+
+    #[pymethods]
+    impl super::FoundSymbolInfo {
+        #[new]
+        #[pyo3(signature=(file, symbol, offset=0))]
+        pub fn py_new(file: file::File, symbol: symbol::Symbol, offset: i64) -> Self {
+            Self::new (
+                file,
+                symbol,
+                offset,
+            )
+        }
+
+        /* Getters and setters */
+
+        #[getter]
+        fn get_file(&self) -> PyResult<file::File> {
+            Ok(self.file.clone())
+        }
+
+        #[setter]
+        fn set_file(&mut self, value: file::File) -> PyResult<()> {
+            self.file = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_symbol(&self) -> PyResult<symbol::Symbol> {
+            Ok(self.symbol.clone())
+        }
+
+        #[setter]
+        fn set_symbol(&mut self, value: symbol::Symbol) -> PyResult<()> {
+            self.symbol = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_offset(&self) -> PyResult<i64> {
+            Ok(self.offset)
+        }
+
+        #[setter]
+        fn set_offset(&mut self, value: i64) -> PyResult<()> {
+            self.offset = value;
+            Ok(())
+        }
+
+        /* Methods */
+
+        #[pyo3(name = "getAsStr")]
+        pub fn getAsStr(&self) -> String {
+            self.get_as_str()
+        }
+
+        #[pyo3(name = "getAsStrPlusOffset")]
+        pub fn getAsStrPlusOffset(&self, sym_name: Option<String>) -> String {
+            self.get_as_str_plus_offset(sym_name)
         }
     }
 }

--- a/src/rs/lib.rs
+++ b/src/rs/lib.rs
@@ -23,6 +23,7 @@ pub use symbol_comparison_info::SymbolComparisonInfo;
 #[macro_use]
 extern crate lazy_static;
 
+#[cfg(feature = "python_bindings")]
 #[pyo3::prelude::pymodule]
 fn mapfile_parser(
     _py: pyo3::prelude::Python<'_>,

--- a/src/rs/mapfile.rs
+++ b/src/rs/mapfile.rs
@@ -724,9 +724,7 @@ pub(crate) mod python_bindings {
     use std::collections::HashMap;
     use std::path::PathBuf;
 
-    use crate::{
-        file, found_symbol_info, maps_comparison_info, progress_stats, segment, symbol,
-    };
+    use crate::{file, found_symbol_info, maps_comparison_info, progress_stats, segment, symbol};
 
     #[pymethods]
     impl super::MapFile {
@@ -801,10 +799,7 @@ pub(crate) mod python_bindings {
             progress_stats::ProgressStats,
             HashMap<String, progress_stats::ProgressStats>,
         ) {
-            self.get_progress(asm_path,
-                nonmatchings,
-                aliases,
-                path_index)
+            self.get_progress(asm_path, nonmatchings, aliases, path_index)
         }
 
         #[pyo3(signature=(other_map_file, *, check_other_on_self=true))]

--- a/src/rs/maps_comparison_info.rs
+++ b/src/rs/maps_comparison_info.rs
@@ -80,7 +80,10 @@ pub(crate) mod python_bindings {
         }
 
         #[setter]
-        fn set_comparedList(&mut self, value: Vec<symbol_comparison_info::SymbolComparisonInfo>) -> PyResult<()> {
+        fn set_comparedList(
+            &mut self,
+            value: Vec<symbol_comparison_info::SymbolComparisonInfo>,
+        ) -> PyResult<()> {
             self.compared_list = value;
             Ok(())
         }

--- a/src/rs/maps_comparison_info.rs
+++ b/src/rs/maps_comparison_info.rs
@@ -5,26 +5,22 @@ use std::collections::HashSet;
 
 use crate::{file, symbol_comparison_info};
 
+#[cfg(feature = "python_bindings")]
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(module = "mapfile_parser")]
+#[cfg_attr(feature = "python_bindings", pyclass(module = "mapfile_parser"))]
 pub struct MapsComparisonInfo {
-    #[pyo3(get, set, name = "badFiles")]
     pub bad_files: HashSet<file::File>,
 
-    #[pyo3(get, set, name = "missingFiles")]
     pub missing_files: HashSet<file::File>,
 
-    #[pyo3(get, set, name = "comparedList")]
     pub compared_list: Vec<symbol_comparison_info::SymbolComparisonInfo>,
 }
 
-#[pymethods]
 impl MapsComparisonInfo {
-    #[new]
     pub fn new() -> Self {
-        MapsComparisonInfo {
+        Self {
             bad_files: HashSet::new(),
             missing_files: HashSet::new(),
             compared_list: Vec::new(),
@@ -35,5 +31,58 @@ impl MapsComparisonInfo {
 impl Default for MapsComparisonInfo {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(feature = "python_bindings")]
+#[allow(non_snake_case)]
+pub(crate) mod python_bindings {
+    use pyo3::prelude::*;
+
+    use std::collections::HashSet;
+
+    use crate::{file, symbol_comparison_info};
+
+    #[pymethods]
+    impl super::MapsComparisonInfo {
+        #[new]
+        pub fn py_new() -> Self {
+            Self::new()
+        }
+
+        /* Getters and setters */
+
+        #[getter]
+        fn get_badFiles(&self) -> PyResult<HashSet<file::File>> {
+            Ok(self.bad_files.clone())
+        }
+
+        #[setter]
+        fn set_badFiles(&mut self, value: HashSet<file::File>) -> PyResult<()> {
+            self.bad_files = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_missingFiles(&self) -> PyResult<HashSet<file::File>> {
+            Ok(self.missing_files.clone())
+        }
+
+        #[setter]
+        fn set_missingFiles(&mut self, value: HashSet<file::File>) -> PyResult<()> {
+            self.missing_files = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_comparedList(&self) -> PyResult<Vec<symbol_comparison_info::SymbolComparisonInfo>> {
+            Ok(self.compared_list.clone())
+        }
+
+        #[setter]
+        fn set_comparedList(&mut self, value: Vec<symbol_comparison_info::SymbolComparisonInfo>) -> PyResult<()> {
+            self.compared_list = value;
+            Ok(())
+        }
     }
 }

--- a/src/rs/segment.rs
+++ b/src/rs/segment.rs
@@ -274,8 +274,8 @@ impl Hash for Segment {
 #[cfg(feature = "python_bindings")]
 #[allow(non_snake_case)]
 pub(crate) mod python_bindings {
-    use pyo3::prelude::*;
     use pyo3::class::basic::CompareOp;
+    use pyo3::prelude::*;
 
     use std::collections::hash_map::DefaultHasher;
 
@@ -455,7 +455,6 @@ pub(crate) mod python_bindings {
 
         // TODO: __str__ and __repr__
     }
-
 
     #[pyclass]
     struct FileVecIter {

--- a/src/rs/segment.rs
+++ b/src/rs/segment.rs
@@ -11,36 +11,25 @@ use std::collections::hash_map::Entry;
 use std::hash::{Hash, Hasher};
 
 #[cfg(feature = "python_bindings")]
-use pyo3::class::basic::CompareOp;
 use pyo3::prelude::*;
-#[cfg(feature = "python_bindings")]
-use std::collections::hash_map::DefaultHasher;
 
 #[derive(Debug, Clone)]
-#[pyclass(module = "mapfile_parser")]
+#[cfg_attr(feature = "python_bindings", pyclass(module = "mapfile_parser"))]
 pub struct Segment {
-    #[pyo3(get, set)]
     pub name: String,
 
-    #[pyo3(get, set)]
     pub vram: u64,
 
-    #[pyo3(get, set)]
     pub size: u64,
 
-    #[pyo3(get, set)]
     pub vrom: u64,
 
-    #[pyo3(get, set)]
     pub align: Option<u64>,
 
-    // #[pyo3(get, set)]
     pub files_list: Vec<file::File>,
 }
 
-#[pymethods]
 impl Segment {
-    #[new]
     pub fn new(name: String, vram: u64, size: u64, vrom: u64, align: Option<u64>) -> Self {
         Segment {
             name,
@@ -52,8 +41,7 @@ impl Segment {
         }
     }
 
-    #[pyo3(name = "filterBySectionType")]
-    pub fn filter_by_section_type(&self, section_type: &str) -> Segment {
+    pub fn filter_by_section_type(&self, section_type: &str) -> Self {
         let mut new_segment = self.clone_no_filelist();
 
         for file in &self.files_list {
@@ -65,8 +53,7 @@ impl Segment {
         new_segment
     }
 
-    #[pyo3(name = "getEveryFileExceptSectionType")]
-    pub fn get_every_file_except_section_type(&self, section_type: &str) -> Segment {
+    pub fn get_every_file_except_section_type(&self, section_type: &str) -> Self {
         let mut new_segment = self.clone_no_filelist();
 
         for file in &self.files_list {
@@ -78,7 +65,6 @@ impl Segment {
         new_segment
     }
 
-    #[pyo3(name = "findSymbolByName")]
     pub fn find_symbol_by_name(
         &self,
         sym_name: &str,
@@ -94,7 +80,6 @@ impl Segment {
         None
     }
 
-    #[pyo3(name = "findSymbolByVramOrVrom")]
     pub fn find_symbol_by_vram_or_vrom(
         &self,
         address: u64,
@@ -114,8 +99,7 @@ impl Segment {
         None
     }
 
-    #[pyo3(name = "mixFolders")]
-    pub fn mix_folders(&self) -> Segment {
+    pub fn mix_folders(&self) -> Self {
         let mut new_segment = self.clone_no_filelist();
 
         // <PathBuf, Vec<File>>
@@ -172,7 +156,6 @@ impl Segment {
         new_segment
     }
 
-    #[pyo3(name = "toCsv", signature=(print_vram=true, skip_without_symbols=true))]
     pub fn to_csv(&self, print_vram: bool, skip_without_symbols: bool) -> String {
         let mut ret = String::new();
 
@@ -187,7 +170,6 @@ impl Segment {
         ret
     }
 
-    #[pyo3(name = "toCsvSymbols")]
     pub fn to_csv_symbols(&self) -> String {
         let mut ret = String::new();
 
@@ -204,78 +186,14 @@ impl Segment {
         ret
     }
 
-    #[pyo3(name = "printAsCsv", signature=(print_vram=true, skip_without_symbols=true))]
     pub fn print_as_csv(&self, print_vram: bool, skip_without_symbols: bool) {
         print!("{}", self.to_csv(print_vram, skip_without_symbols));
     }
 
-    #[pyo3(name = "printSymbolsCsv")]
     pub fn print_symbols_csv(&self) {
         print!("{}", self.to_csv_symbols());
     }
 
-    #[cfg(feature = "python_bindings")]
-    #[pyo3(name = "copyFileList")]
-    fn copy_file_list(&self) -> Vec<file::File> {
-        self.files_list.clone()
-    }
-
-    #[cfg(feature = "python_bindings")]
-    #[pyo3(name = "setFileList")]
-    fn set_file_list(&mut self, new_list: Vec<file::File>) {
-        self.files_list = new_list;
-    }
-
-    #[cfg(feature = "python_bindings")]
-    #[pyo3(name = "appendFile")]
-    fn append_file(&mut self, file: file::File) {
-        self.files_list.push(file);
-    }
-
-    #[cfg(feature = "python_bindings")]
-    fn __iter__(slf: PyRef<'_, Self>) -> PyResult<Py<FileVecIter>> {
-        let iter = FileVecIter {
-            inner: slf.files_list.clone().into_iter(),
-        };
-        Py::new(slf.py(), iter)
-    }
-
-    #[cfg(feature = "python_bindings")]
-    fn __getitem__(&self, index: usize) -> file::File {
-        self.files_list[index].clone()
-    }
-
-    #[cfg(feature = "python_bindings")]
-    fn __setitem__(&mut self, index: usize, element: file::File) {
-        self.files_list[index] = element;
-    }
-
-    #[cfg(feature = "python_bindings")]
-    fn __len__(&self) -> usize {
-        self.files_list.len()
-    }
-
-    // TODO: implement __eq__ instead when PyO3 0.20 releases
-    #[cfg(feature = "python_bindings")]
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyObject {
-        match op {
-            pyo3::class::basic::CompareOp::Eq => (self == other).into_py(py),
-            pyo3::class::basic::CompareOp::Ne => (self != other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
-    #[cfg(feature = "python_bindings")]
-    fn __hash__(&self) -> isize {
-        let mut hasher = DefaultHasher::new();
-        self.hash(&mut hasher);
-        hasher.finish() as isize
-    }
-
-    // TODO: __str__ and __repr__
-}
-
-impl Segment {
     pub fn new_default(name: String, vram: u64, size: u64, vrom: u64) -> Self {
         Segment {
             name,
@@ -354,19 +272,204 @@ impl Hash for Segment {
 }
 
 #[cfg(feature = "python_bindings")]
-#[pyclass]
-struct FileVecIter {
-    inner: std::vec::IntoIter<file::File>,
-}
+#[allow(non_snake_case)]
+pub(crate) mod python_bindings {
+    use pyo3::prelude::*;
+    use pyo3::class::basic::CompareOp;
 
-#[cfg(feature = "python_bindings")]
-#[pymethods]
-impl FileVecIter {
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
-        slf
+    use std::collections::hash_map::DefaultHasher;
+
+    // Required to call the `.hash` and `.finish` methods, which are defined on traits.
+    use std::hash::{Hash, Hasher};
+
+    use crate::{file, found_symbol_info};
+
+    #[pymethods]
+    impl super::Segment {
+        #[new]
+        pub fn py_new(name: String, vram: u64, size: u64, vrom: u64, align: Option<u64>) -> Self {
+            Self::new(name, vram, size, vrom, align)
+        }
+
+        /* Getters and setters */
+
+        #[getter]
+        fn get_name(&self) -> PyResult<String> {
+            Ok(self.name.clone())
+        }
+
+        #[setter]
+        fn set_name(&mut self, value: String) -> PyResult<()> {
+            self.name = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_vram(&self) -> PyResult<u64> {
+            Ok(self.vram)
+        }
+
+        #[setter]
+        fn set_vram(&mut self, value: u64) -> PyResult<()> {
+            self.vram = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_size(&self) -> PyResult<u64> {
+            Ok(self.size)
+        }
+
+        #[setter]
+        fn set_size(&mut self, value: u64) -> PyResult<()> {
+            self.size = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_vrom(&self) -> PyResult<u64> {
+            Ok(self.vrom)
+        }
+
+        #[setter]
+        fn set_vrom(&mut self, value: u64) -> PyResult<()> {
+            self.vrom = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_align(&self) -> PyResult<Option<u64>> {
+            Ok(self.align)
+        }
+
+        #[setter]
+        fn set_align(&mut self, value: Option<u64>) -> PyResult<()> {
+            self.align = value;
+            Ok(())
+        }
+
+        /*
+        #[getter]
+        fn get_files_list(&self) -> PyResult<Vec<file::File>> {
+            Ok(self.files_list)
+        }
+
+        #[setter]
+        fn set_files_list(&mut self, value: Vec<file::File>) -> PyResult<()> {
+            self.files_list = value;
+            Ok(())
+        }
+        */
+
+        /* Methods */
+
+        pub fn filterBySectionType(&self, section_type: &str) -> Self {
+            self.filter_by_section_type(section_type)
+        }
+
+        pub fn getEveryFileExceptSectionType(&self, section_type: &str) -> Self {
+            self.get_every_file_except_section_type(section_type)
+        }
+
+        pub fn findSymbolByName(
+            &self,
+            sym_name: &str,
+        ) -> Option<found_symbol_info::FoundSymbolInfo> {
+            self.find_symbol_by_name(sym_name)
+        }
+
+        pub fn findSymbolByVramOrVrom(
+            &self,
+            address: u64,
+        ) -> Option<found_symbol_info::FoundSymbolInfo> {
+            self.find_symbol_by_vram_or_vrom(address)
+        }
+
+        pub fn mixFolders(&self) -> Self {
+            self.mix_folders()
+        }
+
+        #[pyo3(signature=(print_vram=true, skip_without_symbols=true))]
+        pub fn toCsv(&self, print_vram: bool, skip_without_symbols: bool) -> String {
+            self.to_csv(print_vram, skip_without_symbols)
+        }
+
+        pub fn toCsvSymbols(&self) -> String {
+            self.to_csv_symbols()
+        }
+
+        #[pyo3(signature=(print_vram=true, skip_without_symbols=true))]
+        pub fn printAsCsv(&self, print_vram: bool, skip_without_symbols: bool) {
+            self.print_as_csv(print_vram, skip_without_symbols)
+        }
+
+        pub fn printSymbolsCsv(&self) {
+            self.print_symbols_csv()
+        }
+
+        fn copyFileList(&self) -> Vec<file::File> {
+            self.files_list.clone()
+        }
+
+        fn setFileList(&mut self, new_list: Vec<file::File>) {
+            self.files_list = new_list;
+        }
+
+        fn appendFile(&mut self, file: file::File) {
+            self.files_list.push(file);
+        }
+
+        fn __iter__(slf: PyRef<'_, Self>) -> PyResult<Py<FileVecIter>> {
+            let iter = FileVecIter {
+                inner: slf.files_list.clone().into_iter(),
+            };
+            Py::new(slf.py(), iter)
+        }
+
+        fn __getitem__(&self, index: usize) -> file::File {
+            self.files_list[index].clone()
+        }
+
+        fn __setitem__(&mut self, index: usize, element: file::File) {
+            self.files_list[index] = element;
+        }
+
+        fn __len__(&self) -> usize {
+            self.files_list.len()
+        }
+
+        // TODO: implement __eq__ instead when PyO3 0.20 releases
+        fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyObject {
+            match op {
+                pyo3::class::basic::CompareOp::Eq => (self == other).into_py(py),
+                pyo3::class::basic::CompareOp::Ne => (self != other).into_py(py),
+                _ => py.NotImplemented(),
+            }
+        }
+
+        fn __hash__(&self) -> isize {
+            let mut hasher = DefaultHasher::new();
+            self.hash(&mut hasher);
+            hasher.finish() as isize
+        }
+
+        // TODO: __str__ and __repr__
     }
 
-    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<file::File> {
-        slf.inner.next()
+
+    #[pyclass]
+    struct FileVecIter {
+        inner: std::vec::IntoIter<file::File>,
+    }
+
+    #[pymethods]
+    impl FileVecIter {
+        fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+            slf
+        }
+
+        fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<file::File> {
+            slf.inner.next()
+        }
     }
 }

--- a/src/rs/symbol.rs
+++ b/src/rs/symbol.rs
@@ -4,24 +4,20 @@
 // Required to call the `.hash` and `.finish` methods, which are defined on traits.
 use std::hash::{Hash, Hasher};
 
+#[cfg(feature = "python_bindings")]
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(module = "mapfile_parser")]
+#[cfg_attr(feature = "python_bindings", pyclass(module = "mapfile_parser"))]
 pub struct Symbol {
-    #[pyo3(get)]
     pub name: String,
 
-    #[pyo3(get)]
     pub vram: u64,
 
-    #[pyo3(get, set)]
     pub size: Option<u64>,
 
-    #[pyo3(get, set)]
     pub vrom: Option<u64>,
 
-    #[pyo3(get, set)]
     pub align: Option<u64>,
 }
 
@@ -132,6 +128,53 @@ pub(crate) mod python_bindings {
                 align,
             )
         }
+
+        /* Getters and setters */
+
+        #[getter]
+        fn get_name(&self) -> PyResult<String> {
+            Ok(self.name.clone())
+        }
+
+        #[getter]
+        fn get_vram(&self) -> PyResult<u64> {
+            Ok(self.vram)
+        }
+
+        #[getter]
+        fn get_size(&self) -> PyResult<Option<u64>> {
+            Ok(self.size)
+        }
+
+        #[setter]
+        fn set_size(&mut self, value: Option<u64>) -> PyResult<()> {
+            self.size = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_vrom(&self) -> PyResult<Option<u64>> {
+            Ok(self.vrom)
+        }
+
+        #[setter]
+        fn set_vrom(&mut self, value: Option<u64>) -> PyResult<()> {
+            self.vrom = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_align(&self) -> PyResult<Option<u64>> {
+            Ok(self.align)
+        }
+
+        #[setter]
+        fn set_align(&mut self, value: Option<u64>) -> PyResult<()> {
+            self.align = value;
+            Ok(())
+        }
+
+        /* Methods */
 
         pub fn getVramStr(&self) -> String {
             self.get_vram_str()

--- a/src/rs/symbol.rs
+++ b/src/rs/symbol.rs
@@ -4,11 +4,7 @@
 // Required to call the `.hash` and `.finish` methods, which are defined on traits.
 use std::hash::{Hash, Hasher};
 
-#[cfg(feature = "python_bindings")]
-use pyo3::class::basic::CompareOp;
 use pyo3::prelude::*;
-#[cfg(feature = "python_bindings")]
-use std::collections::hash_map::DefaultHasher;
 
 #[derive(Debug, Clone)]
 #[pyclass(module = "mapfile_parser")]
@@ -29,9 +25,7 @@ pub struct Symbol {
     pub align: Option<u64>,
 }
 
-#[pymethods]
 impl Symbol {
-    #[new]
     pub fn new(
         name: String,
         vram: u64,
@@ -39,7 +33,7 @@ impl Symbol {
         vrom: Option<u64>,
         align: Option<u64>,
     ) -> Self {
-        Symbol {
+        Self {
             name,
             vram,
             size,
@@ -48,12 +42,20 @@ impl Symbol {
         }
     }
 
-    #[pyo3(name = "getVramStr")]
+    pub fn new_default(name: String, vram: u64) -> Self {
+        Self {
+            name,
+            vram,
+            size: None,
+            vrom: None,
+            align: None,
+        }
+    }
+
     pub fn get_vram_str(&self) -> String {
         format!("0x{0:08X}", self.vram)
     }
 
-    #[pyo3(name = "getSizeStr")]
     pub fn get_size_str(&self) -> String {
         if let Some(size) = self.size {
             //return format!("0x{0:X}", size);
@@ -62,7 +64,6 @@ impl Symbol {
         "None".into()
     }
 
-    #[pyo3(name = "getVromStr")]
     pub fn get_vrom_str(&self) -> String {
         if let Some(vrom) = self.vrom {
             return format!("0x{0:06X}", vrom);
@@ -70,57 +71,20 @@ impl Symbol {
         "None".into()
     }
 
-    #[staticmethod]
-    #[pyo3(name = "toCsvHeader")]
     pub fn to_csv_header() -> String {
         "Symbol name,VRAM,Size in bytes".to_string()
     }
 
-    #[pyo3(name = "toCsv")]
     pub fn to_csv(&self) -> String {
         format!("{0},{1:08X},{2}", self.name, self.vram, self.get_size_str())
     }
 
-    #[staticmethod]
-    #[pyo3(name = "printCsvHeader")]
     pub fn print_csv_header() {
         print!("{}", Self::to_csv_header());
     }
 
-    #[pyo3(name = "printAsCsv")]
     pub fn print_as_csv(&self) {
         print!("{0}", self.to_csv());
-    }
-
-    // TODO: implement __eq__ instead when PyO3 0.20 releases
-    #[cfg(feature = "python_bindings")]
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyObject {
-        match op {
-            pyo3::class::basic::CompareOp::Eq => (self == other).into_py(py),
-            pyo3::class::basic::CompareOp::Ne => (self != other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
-    #[cfg(feature = "python_bindings")]
-    fn __hash__(&self) -> isize {
-        let mut hasher = DefaultHasher::new();
-        self.hash(&mut hasher);
-        hasher.finish() as isize
-    }
-
-    // TODO: __str__ and __repr__
-}
-
-impl Symbol {
-    pub fn new_default(name: String, vram: u64) -> Self {
-        Symbol {
-            name,
-            vram,
-            size: None,
-            vrom: None,
-            align: None,
-        }
     }
 }
 
@@ -137,5 +101,83 @@ impl Hash for Symbol {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.name.hash(state);
         self.vram.hash(state);
+    }
+}
+
+#[cfg(feature = "python_bindings")]
+#[allow(non_snake_case)]
+pub(crate) mod python_bindings {
+    use pyo3::class::basic::CompareOp;
+    use pyo3::prelude::*;
+
+    use std::collections::hash_map::DefaultHasher;
+
+    // Required to call the `.hash` and `.finish` methods, which are defined on traits.
+    use std::hash::{Hash, Hasher};
+
+    #[pymethods]
+    impl super::Symbol {
+        #[new]
+        pub fn py_new(
+            name: String,
+            vram: u64,
+            size: Option<u64>,
+            vrom: Option<u64>,
+            align: Option<u64>,
+        ) -> Self {
+            Self::new(name,
+                vram,
+                size,
+                vrom,
+                align,
+            )
+        }
+
+        pub fn getVramStr(&self) -> String {
+            self.get_vram_str()
+        }
+
+        pub fn getSizeStr(&self) -> String {
+            self.get_size_str()
+        }
+
+        pub fn getVromStr(&self) -> String {
+            self.get_vrom_str()
+        }
+
+        #[staticmethod]
+        pub fn toCsvHeader() -> String {
+            Self::to_csv_header()
+        }
+
+        pub fn toCsv(&self) -> String {
+            self.to_csv()
+        }
+
+        #[staticmethod]
+        pub fn printCsvHeader() {
+            Self::print_csv_header()
+        }
+
+        pub fn printAsCsv(&self) {
+            self.print_as_csv()
+        }
+
+        // TODO: implement __eq__ instead when PyO3 0.20 releases
+        fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyObject {
+            match op {
+                pyo3::class::basic::CompareOp::Eq => (self == other).into_py(py),
+                pyo3::class::basic::CompareOp::Ne => (self != other).into_py(py),
+                _ => py.NotImplemented(),
+            }
+        }
+
+        fn __hash__(&self) -> isize {
+            let mut hasher = DefaultHasher::new();
+            self.hash(&mut hasher);
+            hasher.finish() as isize
+        }
+
+        // TODO: __str__ and __repr__
     }
 }

--- a/src/rs/symbol.rs
+++ b/src/rs/symbol.rs
@@ -137,9 +137,21 @@ pub(crate) mod python_bindings {
             Ok(self.name.clone())
         }
 
+        #[setter]
+        fn set_name(&mut self, value: String) -> PyResult<()> {
+            self.name = value;
+            Ok(())
+        }
+
         #[getter]
         fn get_vram(&self) -> PyResult<u64> {
             Ok(self.vram)
+        }
+
+        #[setter]
+        fn set_vram(&mut self, value: u64) -> PyResult<()> {
+            self.vram = value;
+            Ok(())
         }
 
         #[getter]

--- a/src/rs/symbol.rs
+++ b/src/rs/symbol.rs
@@ -121,12 +121,7 @@ pub(crate) mod python_bindings {
             vrom: Option<u64>,
             align: Option<u64>,
         ) -> Self {
-            Self::new(name,
-                vram,
-                size,
-                vrom,
-                align,
-            )
+            Self::new(name, vram, size, vrom, align)
         }
 
         /* Getters and setters */

--- a/src/rs/symbol.rs
+++ b/src/rs/symbol.rs
@@ -4,12 +4,11 @@
 // Required to call the `.hash` and `.finish` methods, which are defined on traits.
 use std::hash::{Hash, Hasher};
 
-//#[cfg(feature = "python_bindings")]
+#[cfg(feature = "python_bindings")]
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-//#[cfg_attr(feature = "python_bindings", pyclass(module = "mapfile_parser"))]
-#[pyclass(module = "mapfile_parser")]
+#[cfg_attr(feature = "python_bindings", pyclass(module = "mapfile_parser"))]
 pub struct Symbol {
     pub name: String,
 
@@ -101,7 +100,7 @@ impl Hash for Symbol {
     }
 }
 
-//#[cfg(feature = "python_bindings")]
+#[cfg(feature = "python_bindings")]
 #[allow(non_snake_case)]
 pub(crate) mod python_bindings {
     use pyo3::class::basic::CompareOp;

--- a/src/rs/symbol.rs
+++ b/src/rs/symbol.rs
@@ -4,11 +4,12 @@
 // Required to call the `.hash` and `.finish` methods, which are defined on traits.
 use std::hash::{Hash, Hasher};
 
-#[cfg(feature = "python_bindings")]
+//#[cfg(feature = "python_bindings")]
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "python_bindings", pyclass(module = "mapfile_parser"))]
+//#[cfg_attr(feature = "python_bindings", pyclass(module = "mapfile_parser"))]
+#[pyclass(module = "mapfile_parser")]
 pub struct Symbol {
     pub name: String,
 
@@ -100,7 +101,7 @@ impl Hash for Symbol {
     }
 }
 
-#[cfg(feature = "python_bindings")]
+//#[cfg(feature = "python_bindings")]
 #[allow(non_snake_case)]
 pub(crate) mod python_bindings {
     use pyo3::class::basic::CompareOp;

--- a/src/rs/symbol_comparison_info.rs
+++ b/src/rs/symbol_comparison_info.rs
@@ -2,34 +2,27 @@
 /* SPDX-License-Identifier: MIT */
 
 use crate::{file, symbol};
+
+#[cfg(feature = "python_bindings")]
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(module = "mapfile_parser")]
+#[cfg_attr(feature = "python_bindings", pyclass(module = "mapfile_parser"))]
 pub struct SymbolComparisonInfo {
-    #[pyo3(get, set)]
     pub symbol: symbol::Symbol,
 
-    #[pyo3(get, set, name = "buildAddress")]
     pub build_address: u64,
 
-    #[pyo3(get, set, name = "buildFile")]
     pub build_file: Option<file::File>,
 
-    #[pyo3(get, set, name = "expectedAddress")]
     pub expected_address: u64,
 
-    #[pyo3(get, set, name = "expectedFile")]
     pub expected_file: Option<file::File>,
 
-    #[pyo3(get, set)]
     pub diff: Option<i64>,
 }
 
-#[pymethods]
 impl SymbolComparisonInfo {
-    #[new]
-    #[pyo3(signature = (symbol, build_address, build_file, expected_address, expected_file, diff))]
     pub fn new(
         symbol: symbol::Symbol,
         build_address: u64,
@@ -38,13 +31,108 @@ impl SymbolComparisonInfo {
         expected_file: Option<file::File>,
         diff: Option<i64>,
     ) -> Self {
-        SymbolComparisonInfo {
+        Self {
             symbol,
             build_address,
             build_file,
             expected_address,
             expected_file,
             diff,
+        }
+    }
+}
+
+#[cfg(feature = "python_bindings")]
+#[allow(non_snake_case)]
+pub(crate) mod python_bindings {
+    use pyo3::prelude::*;
+
+    use crate::{file, symbol};
+
+    #[pymethods]
+    impl super::SymbolComparisonInfo {
+        #[new]
+        #[pyo3(signature = (symbol, build_address, build_file, expected_address, expected_file, diff))]
+        pub fn py_new(
+            symbol: symbol::Symbol,
+            build_address: u64,
+            build_file: Option<file::File>,
+            expected_address: u64,
+            expected_file: Option<file::File>,
+            diff: Option<i64>,
+        ) -> Self {
+            Self::new (
+                symbol,
+                build_address,
+                build_file,
+                expected_address,
+                expected_file,
+                diff,
+            )
+        }
+
+        /* Getters and setters */
+
+        #[getter]
+        fn get_symbol(&self) -> PyResult<symbol::Symbol> {
+            Ok(self.symbol.clone())
+        }
+        #[setter]
+        fn set_symbol(&mut self, value: symbol::Symbol) -> PyResult<()> {
+            self.symbol = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_buildAddress(&self) -> PyResult<u64> {
+            Ok(self.build_address)
+        }
+        #[setter]
+        fn set_buildAddress(&mut self, value: u64) -> PyResult<()> {
+            self.build_address = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_buildFile(&self) -> PyResult<Option<file::File>> {
+            Ok(self.build_file.clone())
+        }
+        #[setter]
+        fn set_buildFile(&mut self, value: Option<file::File>) -> PyResult<()> {
+            self.build_file = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_expectedAddress(&self) -> PyResult<u64> {
+            Ok(self.expected_address.clone())
+        }
+        #[setter]
+        fn set_expectedAddress(&mut self, value: u64) -> PyResult<()> {
+            self.expected_address = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_expectedFile(&self) -> PyResult<Option<file::File>> {
+            Ok(self.expected_file.clone())
+        }
+
+        #[setter]
+        fn set_expectedFile(&mut self, value: Option<file::File>) -> PyResult<()> {
+            self.expected_file = value;
+            Ok(())
+        }
+
+        #[getter]
+        fn get_diff(&self) -> PyResult<Option<i64>> {
+            Ok(self.diff.clone())
+        }
+
+        #[setter]
+        fn set_diff(&mut self, value: Option<i64>) -> PyResult<()> {
+            self.diff = value;
+            Ok(())
         }
     }
 }

--- a/src/rs/symbol_comparison_info.rs
+++ b/src/rs/symbol_comparison_info.rs
@@ -61,7 +61,7 @@ pub(crate) mod python_bindings {
             expected_file: Option<file::File>,
             diff: Option<i64>,
         ) -> Self {
-            Self::new (
+            Self::new(
                 symbol,
                 build_address,
                 build_file,

--- a/src/rs/symbol_comparison_info.rs
+++ b/src/rs/symbol_comparison_info.rs
@@ -105,7 +105,7 @@ pub(crate) mod python_bindings {
 
         #[getter]
         fn get_expectedAddress(&self) -> PyResult<u64> {
-            Ok(self.expected_address.clone())
+            Ok(self.expected_address)
         }
         #[setter]
         fn set_expectedAddress(&mut self, value: u64) -> PyResult<()> {
@@ -126,7 +126,7 @@ pub(crate) mod python_bindings {
 
         #[getter]
         fn get_diff(&self) -> PyResult<Option<i64>> {
-            Ok(self.diff.clone())
+            Ok(self.diff)
         }
 
         #[setter]


### PR DESCRIPTION
`pyo3` is no longer needed to use this crate as Rust-only library.