### PR TITLE
2.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `MapFile.compareFilesAndSymbols` reporting the wrong address as the
+  expected address.
+
 ## [2.3.4] - 2024-01-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.5] - 2024-02-04
+
 ### Fixed
 
 - Fix `MapFile.compareFilesAndSymbols` reporting the wrong address as the
@@ -312,6 +314,7 @@ Full changes: <https://github.com/Decompollaborate/mapfile_parser/compare/702a73
 - Initial release
 
 [unreleased]: https://github.com/Decompollaborate/mapfile_parser/compare/master...develop
+[2.3.5]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.4...2.3.5
 [2.3.4]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.2...2.3.4
 [2.3.2]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.1...2.3.2
 [2.3.1]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.0...2.3.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "mapfile_parser"
-version = "2.3.4"
+version = "2.3.5"
 edition = "2021"
 authors = ["Anghelo Carvajal <angheloalf95@gmail.com>"]
 description = "Map file parser library focusing decompilation projects"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-mapfile_parser>=2.3.4,<3.0.0
+mapfile_parser>=2.3.5,<3.0.0
 ```
 
 #### Development version
@@ -74,7 +74,7 @@ cargo add mapfile_parser
 Or add the following line manually to your `Cargo.toml` file:
 
 ```toml
-mapfile_parser = "2.3.4"
+mapfile_parser = "2.3.5"
 ```
 
 ## Versioning and changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "2.3.4"
+version = "2.3.5"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (2, 3, 3)
+__version_info__ = (2, 3, 5)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 

--- a/src/mapfile_parser/mapfile.py
+++ b/src/mapfile_parser/mapfile.py
@@ -695,7 +695,7 @@ class MapFile:
                 for symbol in file:
                     foundSymInfo = otherMapFile.findSymbolByName(symbol.name)
                     if foundSymInfo is not None:
-                        comp = SymbolComparisonInfo(symbol, symbol.vram, file, symbol.vram, foundSymInfo.file, symbol.vram - foundSymInfo.symbol.vram)
+                        comp = SymbolComparisonInfo(symbol, symbol.vram, file, foundSymInfo.symbol.vram, foundSymInfo.file, symbol.vram - foundSymInfo.symbol.vram)
                         compInfo.comparedList.append(comp)
                         if comp.diff != 0:
                             compInfo.badFiles.add(file)


### PR DESCRIPTION
## [2.3.5] - 2024-02-04

### Fixed

- Fix `MapFile.compareFilesAndSymbols` reporting the wrong address as the
  expected address.
