### PR TITLE
2.4.0

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install Dependencies
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.8] - 2024-03-25
+
 ### Added
 
 - Add `endian` argument to `doFirstDiff`.
@@ -336,6 +338,7 @@ Full changes: <https://github.com/Decompollaborate/mapfile_parser/compare/702a73
 - Initial release
 
 [unreleased]: https://github.com/Decompollaborate/mapfile_parser/compare/master...develop
+[2.3.8]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.7...2.3.8
 [2.3.7]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.6...2.3.7
 [2.3.6]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.5...2.3.6
 [2.3.5]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.4...2.3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `endian` argument to `doFirstDiff`.
+- Add `--endian` option to `first_diff` script.
+
 ## [2.3.7] - 2024-02-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.3.8] - 2024-03-25
+## [2.4.0] - 2024-03-25
 
 ### Added
 
 - Add `endian` argument to `doFirstDiff`.
 - Add `--endian` option to `first_diff` script.
+
+### Removed
+
+- Dropped Python 3.7 support.
+  - Python 3.8 is the minimum supported version now.
 
 ## [2.3.7] - 2024-02-27
 
@@ -338,7 +343,7 @@ Full changes: <https://github.com/Decompollaborate/mapfile_parser/compare/702a73
 - Initial release
 
 [unreleased]: https://github.com/Decompollaborate/mapfile_parser/compare/master...develop
-[2.3.8]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.7...2.3.8
+[2.4.0]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.7...2.4.0
 [2.3.7]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.6...2.3.7
 [2.3.6]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.5...2.3.6
 [2.3.5]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.4...2.3.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "mapfile_parser"
-version = "2.3.7"
+version = "2.3.8"
 edition = "2021"
 authors = ["Anghelo Carvajal <angheloalf95@gmail.com>"]
 description = "Map file parser library focusing decompilation projects"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "mapfile_parser"
-version = "2.3.8"
+version = "2.4.0"
 edition = "2021"
 authors = ["Anghelo Carvajal <angheloalf95@gmail.com>"]
 description = "Map file parser library focusing decompilation projects"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-mapfile_parser>=2.3.8,<3.0.0
+mapfile_parser>=2.4.0,<3.0.0
 ```
 
 #### Development version
@@ -74,7 +74,7 @@ cargo add mapfile_parser
 Or add the following line manually to your `Cargo.toml` file:
 
 ```toml
-mapfile_parser = "2.3.8"
+mapfile_parser = "2.4.0"
 ```
 
 ## Versioning and changelog

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-mapfile_parser>=2.3.7,<3.0.0
+mapfile_parser>=2.3.8,<3.0.0
 ```
 
 #### Development version
@@ -74,7 +74,7 @@ cargo add mapfile_parser
 Or add the following line manually to your `Cargo.toml` file:
 
 ```toml
-mapfile_parser = "2.3.5"
+mapfile_parser = "2.3.8"
 ```
 
 ## Versioning and changelog

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
-python_version = 3.7
+python_version = 3.8
 check_untyped_defs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "2.3.7"
+version = "2.3.8"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,10 @@
 
 [project]
 name = "mapfile_parser"
-version = "2.3.8"
+version = "2.4.0"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "requests"
 ]

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (2, 3, 8)
+__version_info__ = (2, 4, 0)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (2, 3, 7)
+__version_info__ = (2, 3, 8)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 


### PR DESCRIPTION
## [2.4.0] - 2024-03-25

### Added

- Add `endian` argument to `doFirstDiff`.
- Add `--endian` option to `first_diff` script.

### Removed

- Dropped Python 3.7 support.
  - Python 3.8 is the minimum supported version now.
