### PR TITLE
2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0] - 2024-08-26
+
 ### Added
 
 - Add new parameters to `bss_check.printSymbolComparison`.
@@ -390,6 +392,7 @@ Full changes: <https://github.com/Decompollaborate/mapfile_parser/compare/702a73
 - Initial release
 
 [unreleased]: https://github.com/Decompollaborate/mapfile_parser/compare/master...develop
+[2.6.0]: https://github.com/Decompollaborate/mapfile_parser/compare/2.5.1...2.6.0
 [2.5.1]: https://github.com/Decompollaborate/mapfile_parser/compare/2.5.0...2.5.1
 [2.5.0]: https://github.com/Decompollaborate/mapfile_parser/compare/2.4.0...2.5.0
 [2.4.0]: https://github.com/Decompollaborate/mapfile_parser/compare/2.3.7...2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Minor cleanups
+
 ## [2.5.1] - 2024-08-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new parameters to `bss_check.printSymbolComparison`.
+  - `printGoods`: Allows toggling printing the GOOD symbols.
+  - `printingStyle`: The style to use to print the symbols, either `"csv"` or `"listing"`.
+  - TODO: port to Rust.
+
 ### Changed
 
 - Minor cleanups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add new parameters to `bss_check.printSymbolComparison`.
   - `printGoods`: Allows toggling printing the GOOD symbols.
-  - `printingStyle`: The style to use to print the symbols, either `"csv"` or `"listing"`.
+  - `printingStyle`: The style to use to print the symbols, either `"csv"` or
+    `"listing"`.
   - TODO: port to Rust.
+- New `MapFile.fixupNonMatchingSymbols` method.
+  - Allows to fixup size calculation of symbols messed up by symbols with the
+    same name suffixed with `.NON_MATCHING`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `MapFile.fixupNonMatchingSymbols` method.
   - Allows to fixup size calculation of symbols messed up by symbols with the
     same name suffixed with `.NON_MATCHING`.
+- Add support for `.NON_MATCHING` suffix on symbols on progress calculation.
+  - If a symbol exists and has a `.NON_MATCHING`-suffixed counterpart then
+    consider it not mateched yet.
 
 ### Changed
 
-- Minor cleanups
+- Minor cleanups.
 
 ## [2.5.1] - 2024-08-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "mapfile_parser"
-version = "2.5.1"
+version = "2.5.2-dev0"
 dependencies = [
  "lazy_static",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "mapfile_parser"
-version = "2.5.2-dev0"
+version = "2.6.0"
 dependencies = [
  "lazy_static",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "mapfile_parser"
-version = "2.5.1"
+version = "2.5.2-dev0"
 edition = "2021"
 rust-version = "1.65.0"
 authors = ["Anghelo Carvajal <angheloalf95@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "mapfile_parser"
-version = "2.5.2-dev0"
+version = "2.6.0"
 edition = "2021"
 rust-version = "1.65.0"
 authors = ["Anghelo Carvajal <angheloalf95@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-mapfile_parser>=2.5.1,<3.0.0
+mapfile_parser>=2.6.0,<3.0.0
 ```
 
 #### Development version
@@ -74,7 +74,7 @@ cargo add mapfile_parser
 Or add the following line manually to your `Cargo.toml` file:
 
 ```toml
-mapfile_parser = "2.5.1"
+mapfile_parser = "2.6.0"
 ```
 
 ## Versioning and changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "2.5.2-dev0"
+version = "2.6.0"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "2.5.1"
+version = "2.5.2-dev0"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (2, 5, 2)
-__version__ = ".".join(map(str, __version_info__)) + "-dev0"
+__version_info__ = (2, 6, 0)
+__version__ = ".".join(map(str, __version_info__))# + "-dev0"
 __author__ = "Decompollaborate"
 
 from . import utils as utils

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (2, 5, 1)
-__version__ = ".".join(map(str, __version_info__))# + "-dev0"
+__version_info__ = (2, 5, 2)
+__version__ = ".".join(map(str, __version_info__)) + "-dev0"
 __author__ = "Decompollaborate"
 
 from . import utils as utils

--- a/src/mapfile_parser/frontends/jsonify.py
+++ b/src/mapfile_parser/frontends/jsonify.py
@@ -12,13 +12,15 @@ from pathlib import Path
 from .. import mapfile
 
 
-def doJsonify(mapPath: Path, outputPath: Path|None, humanReadable: bool=True) -> int:
+def doJsonify(mapPath: Path, outputPath: Path|None, humanReadable: bool=True, applyFixes: bool=False) -> int:
     if not mapPath.exists():
         print(f"Could not find mapfile at '{mapPath}'")
         return 1
 
     mapFile = mapfile.MapFile()
     mapFile.readMapFile(mapPath)
+    if applyFixes:
+        mapFile = mapFile.fixupNonMatchingSymbols()
 
     jsonStr = json.dumps(mapFile.toJson(humanReadable=humanReadable), indent=4)
 
@@ -35,8 +37,9 @@ def processArguments(args: argparse.Namespace):
     mapPath: Path = args.mapfile
     outputPath: Path|None = Path(args.output) if args.output is not None else None
     machine: bool = args.machine
+    applyFixes: bool = args.applyFixes
 
-    exit(doJsonify(mapPath, outputPath, humanReadable=not machine))
+    exit(doJsonify(mapPath, outputPath, humanReadable=not machine, applyFixes=applyFixes))
 
 def addSubparser(subparser: argparse._SubParsersAction[argparse.ArgumentParser]):
     parser = subparser.add_parser("jsonify", help="Converts a mapfile into a json format.")
@@ -44,5 +47,6 @@ def addSubparser(subparser: argparse._SubParsersAction[argparse.ArgumentParser])
     parser.add_argument("mapfile", help="Path to a map file", type=Path)
     parser.add_argument("-o", "--output", help="Output path of for the generated json. If omitted then stdout is used instead.")
     parser.add_argument("-m", "--machine", help="Emit numbers as numbers instead of outputting them as pretty strings.", action="store_true")
+    parser.add_argument("-f", "--apply-fixes", help="Apply certain fixups, like fixing size calculation of because of the existence of fake `.NON_MATCHING` symbols.", action="store_true")
 
     parser.set_defaults(func=processArguments)

--- a/src/mapfile_parser/frontends/progress.py
+++ b/src/mapfile_parser/frontends/progress.py
@@ -18,7 +18,7 @@ def getProgress(mapPath: Path, asmPath: Path, nonmatchingsPath: Path, pathIndex:
     mapFile.debugging = debugging
     mapFile.readMapFile(mapPath)
 
-    return mapFile.filterBySectionType(".text").getProgress(asmPath, nonmatchingsPath, pathIndex=pathIndex)
+    return mapFile.filterBySectionType(".text").fixupNonMatchingSymbols().getProgress(asmPath, nonmatchingsPath, pathIndex=pathIndex)
 
 def doProgress(mapPath: Path, asmPath: Path, nonmatchingsPath: Path, pathIndex: int=2, debugging: bool=False) -> int:
     if not mapPath.exists():

--- a/src/mapfile_parser/frontends/progress.py
+++ b/src/mapfile_parser/frontends/progress.py
@@ -12,20 +12,20 @@ from .. import mapfile
 from .. import progress_stats
 
 
-def getProgress(mapPath: Path, asmPath: Path, nonmatchingsPath: Path, pathIndex: int=2, debugging: bool=False) -> tuple[progress_stats.ProgressStats, dict[str, progress_stats.ProgressStats]]:
+def getProgress(mapPath: Path, asmPath: Path, nonmatchingsPath: Path, pathIndex: int=2, checkFunctionFiles: bool=True, debugging: bool=False) -> tuple[progress_stats.ProgressStats, dict[str, progress_stats.ProgressStats]]:
     mapFile = mapfile.MapFile()
 
     mapFile.debugging = debugging
     mapFile.readMapFile(mapPath)
 
-    return mapFile.filterBySectionType(".text").fixupNonMatchingSymbols().getProgress(asmPath, nonmatchingsPath, pathIndex=pathIndex)
+    return mapFile.filterBySectionType(".text").fixupNonMatchingSymbols().getProgress(asmPath, nonmatchingsPath, pathIndex=pathIndex, checkFunctionFiles=checkFunctionFiles)
 
-def doProgress(mapPath: Path, asmPath: Path, nonmatchingsPath: Path, pathIndex: int=2, debugging: bool=False) -> int:
+def doProgress(mapPath: Path, asmPath: Path, nonmatchingsPath: Path, pathIndex: int=2, checkFunctionFiles: bool=True, debugging: bool=False) -> int:
     if not mapPath.exists():
         print(f"Could not find mapfile at '{mapPath}'")
         return 1
 
-    totalStats, progressPerFolder = getProgress(mapPath, asmPath, nonmatchingsPath, pathIndex=pathIndex, debugging=debugging)
+    totalStats, progressPerFolder = getProgress(mapPath, asmPath, nonmatchingsPath, pathIndex=pathIndex, checkFunctionFiles=checkFunctionFiles, debugging=debugging)
 
     progress_stats.printStats(totalStats, progressPerFolder)
     return 0
@@ -36,9 +36,10 @@ def processArguments(args: argparse.Namespace):
     asmPath: Path = args.asmpath
     nonmatchingsPath: Path = args.nonmatchingspath
     pathIndex: int = args.path_index
+    checkFunctionFiles: bool = not args.avoid_function_files
     debugging: bool = args.debugging #! @deprecated
 
-    exit(doProgress(mapPath, asmPath, nonmatchingsPath, pathIndex=pathIndex, debugging=debugging))
+    exit(doProgress(mapPath, asmPath, nonmatchingsPath, pathIndex=pathIndex, checkFunctionFiles=checkFunctionFiles, debugging=debugging))
 
 def addSubparser(subparser: argparse._SubParsersAction[argparse.ArgumentParser]):
     parser = subparser.add_parser("progress", help="Computes current progress of the matched functions. Relies on a splat (https://github.com/ethteck/splat) folder structure and matched functions not longer having a file.")
@@ -47,6 +48,7 @@ def addSubparser(subparser: argparse._SubParsersAction[argparse.ArgumentParser])
     parser.add_argument("asmpath", help="Path to asm folder", type=Path)
     parser.add_argument("nonmatchingspath", help="Path to nonmatchings folder", type=Path)
     parser.add_argument("-i", "--path-index", help="Specify the index to start reading the file paths. Defaults to 2", type=int, default=2)
+    parser.add_argument("-f", "--avoid-function-files", help="Avoid checking if the assembly file for a function exists as a way to determine if the function has been matched or not", action="store_true")
     parser.add_argument("-d", "--debugging", help="Enable debugging prints. This option is deprecated", action="store_true")
 
     parser.set_defaults(func=processArguments)

--- a/src/mapfile_parser/frontends/upload_frogress.py
+++ b/src/mapfile_parser/frontends/upload_frogress.py
@@ -52,12 +52,12 @@ def uploadEntriesToFrogress(entries: dict[str, int], category: str, url: str, ap
     return 0
 
 
-def doUploadFrogress(mapPath: Path, asmPath: Path, nonmatchingsPath: Path, project: str, version: str, category: str, baseurl: str, apikey: str|None=None, verbose: bool=False) -> int:
+def doUploadFrogress(mapPath: Path, asmPath: Path, nonmatchingsPath: Path, project: str, version: str, category: str, baseurl: str, apikey: str|None=None, verbose: bool=False, checkFunctionFiles: bool=True) -> int:
     if not mapPath.exists():
         print(f"Could not find mapfile at '{mapPath}'")
         return 1
 
-    totalStats, progressPerFolder = progress.getProgress(mapPath, asmPath, nonmatchingsPath)
+    totalStats, progressPerFolder = progress.getProgress(mapPath, asmPath, nonmatchingsPath, checkFunctionFiles=checkFunctionFiles)
 
     entries: dict[str, int] = getFrogressEntriesFromStats(totalStats, progressPerFolder, verbose)
 
@@ -75,8 +75,9 @@ def processArguments(args: argparse.Namespace):
     baseurl: str = args.baseurl
     apikey: str|None = args.apikey
     verbose: bool = args.verbose
+    checkFunctionFiles: bool = not args.avoid_function_files
 
-    exit(doUploadFrogress(mapPath, asmPath, nonmatchingsPath, project, version, category, baseurl, apikey, verbose))
+    exit(doUploadFrogress(mapPath, asmPath, nonmatchingsPath, project, version, category, baseurl, apikey, verbose, checkFunctionFiles))
 
 def addSubparser(subparser: argparse._SubParsersAction[argparse.ArgumentParser]):
     parser = subparser.add_parser("upload_frogress", help="Uploads current progress of the matched functions to frogress (https://github.com/decompals/frogress).")
@@ -90,5 +91,6 @@ def addSubparser(subparser: argparse._SubParsersAction[argparse.ArgumentParser])
     parser.add_argument("--baseurl", help="API base URL", default="https://progress.deco.mp")
     parser.add_argument("--apikey", help="API key. Dry run is performed if this option is omitted")
     parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-f", "--avoid-function-files", help="Avoid checking if the assembly file for a function exists as a way to determine if the function has been matched or not", action="store_true")
 
     parser.set_defaults(func=processArguments)

--- a/src/mapfile_parser/mapfile.py
+++ b/src/mapfile_parser/mapfile.py
@@ -146,6 +146,10 @@ class Symbol:
         return result
 
 
+    def clone(self) -> Symbol:
+        return Symbol(self.name, self.vram, self.size, self.vrom, self.align)
+
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Symbol):
             return False
@@ -300,6 +304,13 @@ class File:
     def appendSymbol(self, sym: Symbol) -> None:
         """Appends a copy of `sym` into the internal symbol list"""
         self._symbols.append(sym)
+
+
+    def clone(self) -> File:
+        f = File(self.filepath, self.vram, self.size, self.sectionType, self.vrom, self.align)
+        for sym in self._symbols:
+            f._symbols.append(sym.clone())
+        return f
 
 
     def __iter__(self) -> Generator[Symbol, None, None]:
@@ -474,6 +485,13 @@ class Segment:
     def appendFile(self, file: File) -> None:
         """Appends a copy of `file` into the internal file list"""
         self._filesList.append(file)
+
+
+    def clone(self) -> Segment:
+        s = Segment(self.name, self.vram, self.size, self.vrom, self.align)
+        for f in self._filesList:
+            s._filesList.append(f.clone())
+        return s
 
 
     def __iter__(self) -> Generator[File, None, None]:
@@ -672,6 +690,20 @@ class MapFile:
 
         return newMapFile
 
+    def fixupNonMatchingSymbols(self) -> MapFile:
+        newMapFile = self.clone()
+
+        for segment in newMapFile._segmentsList:
+            for file in segment._filesList:
+                for sym in file._symbols:
+                    if sym.name.endswith(".NON_MATCHING") and sym.size != 0:
+                        realSym = file.findSymbolByName(sym.name.replace(".NON_MATCHING", ""))
+                        if realSym is not None and realSym.size == 0:
+                            realSym.size = sym.size
+                            sym.size = 0
+
+        return newMapFile
+
     def getProgress(self, asmPath: Path, nonmatchings: Path, aliases: dict[str, str]=dict(), pathIndex: int=2) -> tuple[ProgressStats, dict[str, ProgressStats]]:
         totalStats = ProgressStats()
         progressPerFolder: dict[str, ProgressStats] = dict()
@@ -808,6 +840,14 @@ class MapFile:
     def appendSegment(self, segment: Segment) -> None:
         """Appends a copy of `segment` into the internal segment list"""
         self._segmentsList.append(segment)
+
+
+    def clone(self) -> MapFile:
+        m = MapFile()
+        m.debugging = self.debugging
+        for s in self._segmentsList:
+            m._segmentsList.append(s.clone())
+        return m
 
 
     def __iter__(self) -> Generator[Segment, None, None]:

--- a/src/rs/mapfile.rs
+++ b/src/rs/mapfile.rs
@@ -599,6 +599,17 @@ impl MapFile {
         new_map_file
     }
 
+    pub fn fixup_non_matching_symbols(&self) -> Self {
+        let mut new_map_file = self.clone();
+
+        new_map_file
+            .segments_list
+            .iter_mut()
+            .for_each(|x| x.fixup_non_matching_symbols());
+
+        new_map_file
+    }
+
     pub fn get_progress(
         &self,
         asm_path: &Path,
@@ -865,6 +876,10 @@ pub(crate) mod python_bindings {
 
         fn mixFolders(&self) -> Self {
             self.mix_folders()
+        }
+
+        fn fixupNonMatchingSymbols(&self) -> Self {
+            self.fixup_non_matching_symbols()
         }
 
         #[pyo3(signature = (asm_path, nonmatchings, aliases=HashMap::new(), path_index=2))]

--- a/src/rs/mapfile.rs
+++ b/src/rs/mapfile.rs
@@ -616,6 +616,7 @@ impl MapFile {
         nonmatchings: &Path,
         aliases: &HashMap<String, String>,
         path_index: usize,
+        check_function_files: bool,
     ) -> (
         progress_stats::ProgressStats,
         HashMap<String, progress_stats::ProgressStats>,
@@ -661,13 +662,22 @@ impl MapFile {
                 let whole_file_is_undecomped = full_asm_file.exists();
 
                 for func in &file.symbols {
+                    if func.name.ends_with(".NON_MATCHING") {
+                        continue;
+                    }
+
                     let func_asm_path = nonmatchings
                         .join(extensionless_file_path.clone())
                         .join(func.name.clone() + ".s");
 
                     let sym_size = func.size.unwrap_or(0) as usize;
 
-                    if whole_file_is_undecomped || func_asm_path.exists() {
+                    if whole_file_is_undecomped
+                        || self
+                            .find_symbol_by_name(&format!("{}.NON_MATCHING", func.name))
+                            .is_some()
+                        || (check_function_files && func_asm_path.exists())
+                    {
                         total_stats.undecomped_size += sym_size;
                         folder_progress.undecomped_size += sym_size;
                     } else {
@@ -882,18 +892,25 @@ pub(crate) mod python_bindings {
             self.fixup_non_matching_symbols()
         }
 
-        #[pyo3(signature = (asm_path, nonmatchings, aliases=HashMap::new(), path_index=2))]
+        #[pyo3(signature = (asm_path, nonmatchings, aliases=HashMap::new(), path_index=2, check_function_files=true))]
         fn getProgress(
             &self,
             asm_path: PathBuf,
             nonmatchings: PathBuf,
             aliases: HashMap<String, String>,
             path_index: usize,
+            check_function_files: bool,
         ) -> (
             progress_stats::ProgressStats,
             HashMap<String, progress_stats::ProgressStats>,
         ) {
-            self.get_progress(&asm_path, &nonmatchings, &aliases, path_index)
+            self.get_progress(
+                &asm_path,
+                &nonmatchings,
+                &aliases,
+                path_index,
+                check_function_files,
+            )
         }
 
         #[pyo3(signature=(other_map_file, *, check_other_on_self=true))]

--- a/src/rs/segment.rs
+++ b/src/rs/segment.rs
@@ -156,6 +156,12 @@ impl Segment {
         new_segment
     }
 
+    pub fn fixup_non_matching_symbols(&mut self) {
+        self.files_list
+            .iter_mut()
+            .for_each(|x| x.fixup_non_matching_symbols())
+    }
+
     pub fn to_csv(&self, print_vram: bool, skip_without_symbols: bool) -> String {
         let mut ret = String::new();
 
@@ -383,6 +389,10 @@ pub(crate) mod python_bindings {
 
         fn mixFolders(&self) -> Self {
             self.mix_folders()
+        }
+
+        fn fixupNonMatchingSymbols(&mut self) {
+            self.fixup_non_matching_symbols()
         }
 
         #[pyo3(signature=(print_vram=true, skip_without_symbols=true))]

--- a/src/rs/symbol.rs
+++ b/src/rs/symbol.rs
@@ -26,7 +26,7 @@ pub struct Symbol {
 
     // idk if it is worth to continue maintaining this, given the complexity introduced by other features
     #[cfg(feature = "python_bindings")]
-    #[cfg(not(feature = "serde"))]
+    #[cfg_attr(feature = "serde", serde(skip))]
     chached_name: Option<PyObject>,
 }
 
@@ -46,7 +46,6 @@ impl Symbol {
             align,
 
             #[cfg(feature = "python_bindings")]
-            #[cfg(not(feature = "serde"))]
             chached_name: None,
         }
     }
@@ -60,7 +59,6 @@ impl Symbol {
             align: None,
 
             #[cfg(feature = "python_bindings")]
-            #[cfg(not(feature = "serde"))]
             chached_name: None,
         }
     }
@@ -152,7 +150,6 @@ pub(crate) mod python_bindings {
         /* Getters and setters */
 
         #[getter]
-        #[cfg(not(feature = "serde"))]
         fn get_name(&mut self) -> PyObject {
             Python::with_gil(|py| {
                 if self.chached_name.is_none() {
@@ -163,18 +160,8 @@ pub(crate) mod python_bindings {
             })
         }
 
-        #[getter]
-        #[cfg(feature = "serde")]
-        fn get_name(&self) -> PyResult<String> {
-            Ok(self.name.clone())
-        }
-
         #[setter]
         fn set_name(&mut self, value: String) -> PyResult<()> {
-            #[cfg(not(feature = "serde"))]
-            {
-                self.chached_name = None;
-            }
             self.name = value;
             Ok(())
         }


### PR DESCRIPTION
## [2.6.0] - 2024-08-26

### Added

- Add new parameters to `bss_check.printSymbolComparison`.
  - `printGoods`: Allows toggling printing the GOOD symbols.
  - `printingStyle`: The style to use to print the symbols, either `"csv"` or
    `"listing"`.
  - TODO: port to Rust.
- New `MapFile.fixupNonMatchingSymbols` method.
  - Allows to fixup size calculation of symbols messed up by symbols with the
    same name suffixed with `.NON_MATCHING`.
- Add support for `.NON_MATCHING` suffix on symbols on progress calculation.
  - If a symbol exists and has a `.NON_MATCHING`-suffixed counterpart then
    consider it not mateched yet.

### Changed

- Minor cleanups.
