### PR TITLE
2.7.2

### DIFF
--- a/.github/workflows/maturin_upload_pypi.yml
+++ b/.github/workflows/maturin_upload_pypi.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.13'
           architecture: ${{ matrix.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install Dependencies
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Python 3.9 or later is now required.
+  - Bump from Python 3.8 to 3.9.
+  - Older versions can't be checked on CI anymore, so I prefer to not claim to
+    support something that may have broken without anybody noticing.
+  - Nothing really changed. Just the CI tools I was using are refusing to use
+    any Python version older than this. Sorry if you were affected by this.
+
 ## [2.7.1] - 2024-09-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Prebuilt binaries for Python 3.13.
+
 ### Changed
 
 - Python 3.9 or later is now required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.2] - 2024-12-15
+
 ### Added
 
 - Prebuilt binaries for Python 3.13.
@@ -443,6 +445,7 @@ Full changes: <https://github.com/Decompollaborate/mapfile_parser/compare/702a73
 - Initial release
 
 [unreleased]: https://github.com/Decompollaborate/mapfile_parser/compare/master...develop
+[2.7.2]: https://github.com/Decompollaborate/mapfile_parser/compare/2.7.1...2.7.2
 [2.7.1]: https://github.com/Decompollaborate/mapfile_parser/compare/2.7.0...2.7.1
 [2.7.0]: https://github.com/Decompollaborate/mapfile_parser/compare/2.6.0...2.7.0
 [2.6.0]: https://github.com/Decompollaborate/mapfile_parser/compare/2.5.1...2.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     support something that may have broken without anybody noticing.
   - Nothing really changed. Just the CI tools I was using are refusing to use
     any Python version older than this. Sorry if you were affected by this.
+- Use newer pyo3 version.
+  - From 0.20 to 0.23.
+  - Updated to avoid warnings with newer Rust versions.
+  - Fix issues introduced by updating pyo3.
 
 ## [2.7.1] - 2024-09-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "bitflags"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,9 +25,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indoc"
@@ -52,16 +46,6 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "mapfile_parser"
@@ -95,29 +79,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,15 +95,15 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "e484fd2c8b4cb67ab05a318f1fd6fa8f199fcc30819f08f07d200809dba26c15"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -152,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "dc0e0469a84f208e20044b98965e1561028180219e35352a2afaf2b942beff3b"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -162,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "eb1547a7f9966f6f1a0f0227564a9945fe36b90da5a93b3933fc3dc03fae372d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -172,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "fdb6da8ec6fa5cedd1626c886fc8749bdcbb09424a86461eb8cdf096b7c33257"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -184,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "38a385202ff5a92791168b1136afae5059d3ac118457bb7bc304c197c2d33e7d"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -202,15 +163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -243,12 +195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
 version = "1.0.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,12 +213,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "syn"
@@ -302,67 +242,3 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "mapfile_parser"
-version = "2.7.1"
+version = "2.7.2"
 dependencies = [
  "lazy_static",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 regex = "1.10.2"
-pyo3 = { version = "0.23.2", optional = true, features = ["abi3"]}
+pyo3 = { version = "0.23.2", optional = true, features = ["extension-module"]}
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 regex = "1.10.2"
-pyo3 = { version = "0.20.0", optional = true, features = ["abi3", "abi3-py37"]}
+pyo3 = { version = "0.23.2", optional = true, features = ["abi3"]}
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "mapfile_parser"
-version = "2.7.1"
+version = "2.7.2"
 edition = "2021"
 rust-version = "1.65.0"
 authors = ["Anghelo Carvajal <angheloalf95@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-mapfile_parser>=2.7.1,<3.0.0
+mapfile_parser>=2.7.2,<3.0.0
 ```
 
 #### Development version
@@ -74,7 +74,7 @@ cargo add mapfile_parser
 Or add the following line manually to your `Cargo.toml` file:
 
 ```toml
-mapfile_parser = "2.7.1"
+mapfile_parser = "2.7.2"
 ```
 
 ## Versioning and changelog

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
-python_version = 3.8
+python_version = 3.9
 check_untyped_defs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ name = "mapfile_parser"
 version = "2.7.1"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "requests"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "2.7.1"
+version = "2.7.2"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (2, 7, 1)
+__version_info__ = (2, 7, 2)
 __version__ = ".".join(map(str, __version_info__))# + "-dev0"
 __author__ = "Decompollaborate"
 

--- a/src/rs/file.rs
+++ b/src/rs/file.rs
@@ -390,8 +390,10 @@ pub(crate) mod python_bindings {
 
     use std::collections::hash_map::DefaultHasher;
 
+    use super::*;
+
     #[pymethods]
-    impl super::File {
+    impl File {
         #[new]
         fn py_new(
             filepath: PathBuf,

--- a/src/rs/file.rs
+++ b/src/rs/file.rs
@@ -379,7 +379,7 @@ impl Hash for File {
 #[cfg(feature = "python_bindings")]
 #[allow(non_snake_case)]
 pub(crate) mod python_bindings {
-    use pyo3::{intern, prelude::*};
+    use pyo3::{intern, prelude::*, IntoPyObjectExt};
 
     use std::path::PathBuf;
 
@@ -395,6 +395,7 @@ pub(crate) mod python_bindings {
     #[pymethods]
     impl File {
         #[new]
+        #[pyo3(signature = (filepath, vram, size, section_type, vrom=None, align=None))]
         fn py_new(
             filepath: PathBuf,
             vram: u64,
@@ -416,7 +417,7 @@ pub(crate) mod python_bindings {
                 let pathlib_path = pathlib.getattr(intern!(py, "Path"))?;
                 let args = (self.filepath.clone(),);
 
-                Ok(pathlib_path.call1(args)?.to_object(py))
+                pathlib_path.call1(args)?.into_py_any(py)
             })
         }
 

--- a/src/rs/found_symbol_info.rs
+++ b/src/rs/found_symbol_info.rs
@@ -132,6 +132,7 @@ pub(crate) mod python_bindings {
         }
 
         #[pyo3(name = "getAsStrPlusOffset")]
+        #[pyo3(signature = (sym_name=None))]
         fn getAsStrPlusOffset(&self, sym_name: Option<String>) -> String {
             let temp = super::FoundSymbolInfo::from(self);
             temp.get_as_str_plus_offset(sym_name)

--- a/src/rs/found_symbol_info.rs
+++ b/src/rs/found_symbol_info.rs
@@ -144,7 +144,7 @@ pub(crate) mod python_bindings {
         }
     }
 
-    impl<'a> From<super::FoundSymbolInfo<'a>> for PyFoundSymbolInfo {
+    impl From<super::FoundSymbolInfo<'_>> for PyFoundSymbolInfo {
         fn from(value: super::FoundSymbolInfo) -> Self {
             Self::new(value.file.clone(), value.symbol.clone(), value.offset)
         }

--- a/src/rs/lib.rs
+++ b/src/rs/lib.rs
@@ -28,7 +28,7 @@ use pyo3::prelude::*;
 
 #[cfg(feature = "python_bindings")]
 #[pymodule]
-fn mapfile_parser(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn mapfile_parser(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<mapfile::MapFile>()?;
     m.add_class::<segment::Segment>()?;
     m.add_class::<file::File>()?;

--- a/src/rs/maps_comparison_info.rs
+++ b/src/rs/maps_comparison_info.rs
@@ -14,7 +14,7 @@ pub struct MapsComparisonInfo<'a> {
     pub compared_list: Vec<symbol_comparison_info::SymbolComparisonInfo<'a>>,
 }
 
-impl<'a> MapsComparisonInfo<'a> {
+impl MapsComparisonInfo<'_> {
     pub fn new() -> Self {
         Self {
             bad_files: HashSet::new(),
@@ -24,7 +24,7 @@ impl<'a> MapsComparisonInfo<'a> {
     }
 }
 
-impl<'a> Default for MapsComparisonInfo<'a> {
+impl Default for MapsComparisonInfo<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -116,7 +116,7 @@ pub(crate) mod python_bindings {
         }
     }
 
-    impl<'a> From<super::MapsComparisonInfo<'a>> for PyMapsComparisonInfo {
+    impl From<super::MapsComparisonInfo<'_>> for PyMapsComparisonInfo {
         fn from(value: super::MapsComparisonInfo) -> Self {
             Self {
                 bad_files: value.bad_files.into_iter().cloned().collect(),

--- a/src/rs/segment.rs
+++ b/src/rs/segment.rs
@@ -328,6 +328,7 @@ pub(crate) mod python_bindings {
     #[pymethods]
     impl super::Segment {
         #[new]
+        #[pyo3(signature = (name, vram, size, vrom, align=None))]
         fn py_new(name: String, vram: u64, size: u64, vrom: u64, align: Option<u64>) -> Self {
             Self::new(name, vram, size, vrom, align)
         }

--- a/src/rs/symbol.rs
+++ b/src/rs/symbol.rs
@@ -23,11 +23,6 @@ pub struct Symbol {
     pub vrom: Option<u64>,
 
     pub align: Option<u64>,
-
-    // idk if it is worth to continue maintaining this, given the complexity introduced by other features
-    #[cfg(feature = "python_bindings")]
-    #[cfg_attr(feature = "serde", serde(skip))]
-    chached_name: Option<PyObject>,
 }
 
 impl Symbol {
@@ -44,9 +39,6 @@ impl Symbol {
             size,
             vrom,
             align,
-
-            #[cfg(feature = "python_bindings")]
-            chached_name: None,
         }
     }
 
@@ -57,9 +49,6 @@ impl Symbol {
             size: None,
             vrom: None,
             align: None,
-
-            #[cfg(feature = "python_bindings")]
-            chached_name: None,
         }
     }
 
@@ -125,8 +114,7 @@ impl Hash for Symbol {
 #[cfg(feature = "python_bindings")]
 #[allow(non_snake_case)]
 pub(crate) mod python_bindings {
-    use pyo3::prelude::*;
-    use pyo3::types::IntoPyDict;
+    use pyo3::{prelude::*, types::IntoPyDict, IntoPyObjectExt};
 
     use std::collections::hash_map::DefaultHasher;
 
@@ -150,14 +138,8 @@ pub(crate) mod python_bindings {
         /* Getters and setters */
 
         #[getter]
-        fn get_name(&mut self) -> PyObject {
-            Python::with_gil(|py| {
-                if self.chached_name.is_none() {
-                    self.chached_name = Some(self.name.to_object(py));
-                }
-
-                self.chached_name.as_ref().unwrap().to_object(py)
-            })
+        fn get_name(&self) -> PyResult<&str> {
+            Ok(&self.name)
         }
 
         #[setter]
@@ -213,58 +195,58 @@ pub(crate) mod python_bindings {
         /* Serializers */
 
         #[pyo3(signature=(_humanReadable=true))]
-        fn serializeName(&self, _humanReadable: bool) -> PyObject {
-            Python::with_gil(|py| self.name.to_object(py))
+        fn serializeName(&self, _humanReadable: bool) -> PyResult<PyObject> {
+            Python::with_gil(|py| self.name.clone().into_py_any(py))
         }
 
         #[pyo3(signature=(humanReadable=true))]
-        fn serializeVram(&self, humanReadable: bool) -> PyObject {
+        fn serializeVram(&self, humanReadable: bool) -> PyResult<PyObject> {
             Python::with_gil(|py| {
                 if humanReadable {
-                    return format!("0x{:08X}", self.vram).to_object(py);
+                    return format!("0x{:08X}", self.vram).into_py_any(py);
                 }
 
-                self.vram.to_object(py)
+                self.vram.into_py_any(py)
             })
         }
 
         #[pyo3(signature=(humanReadable=true))]
-        fn serializeSize(&self, humanReadable: bool) -> PyObject {
+        fn serializeSize(&self, humanReadable: bool) -> PyResult<PyObject> {
             Python::with_gil(|py| match self.size {
-                None => Python::None(py),
+                None => Ok(Python::None(py)),
                 Some(size) => {
                     if humanReadable {
-                        return format!("0x{:X}", size).to_object(py);
+                        return format!("0x{:X}", size).into_py_any(py);
                     }
-                    size.to_object(py)
+                    size.into_py_any(py)
                 }
             })
         }
 
         #[pyo3(signature=(humanReadable=true))]
-        fn serializeVrom(&self, humanReadable: bool) -> PyObject {
+        fn serializeVrom(&self, humanReadable: bool) -> PyResult<PyObject> {
             Python::with_gil(|py| match self.vrom {
-                None => Python::None(py),
+                None => Ok(Python::None(py)),
                 Some(vrom) => {
                     if humanReadable {
-                        return format!("0x{:06X}", vrom).to_object(py);
+                        return format!("0x{:06X}", vrom).into_py_any(py);
                     }
-                    vrom.to_object(py)
+                    vrom.into_py_any(py)
                 }
             })
         }
 
         #[pyo3(signature=(humanReadable=true))]
-        fn toJson(&self, humanReadable: bool) -> PyObject {
+        fn toJson(&self, humanReadable: bool) -> PyResult<PyObject> {
             Python::with_gil(|py| {
                 [
-                    ("name", self.serializeName(humanReadable)),
-                    ("vram", self.serializeVram(humanReadable)),
-                    ("size", self.serializeSize(humanReadable)),
-                    ("vrom", self.serializeVrom(humanReadable)),
+                    ("name", self.serializeName(humanReadable)?),
+                    ("vram", self.serializeVram(humanReadable)?),
+                    ("size", self.serializeSize(humanReadable)?),
+                    ("vrom", self.serializeVrom(humanReadable)?),
                 ]
-                .into_py_dict(py)
-                .to_object(py)
+                .into_py_dict(py)?
+                .into_py_any(py)
             })
         }
 

--- a/src/rs/symbol_comparison_info.rs
+++ b/src/rs/symbol_comparison_info.rs
@@ -174,7 +174,7 @@ pub(crate) mod python_bindings {
         }
     }
 
-    impl<'a> From<super::SymbolComparisonInfo<'a>> for PySymbolComparisonInfo {
+    impl From<super::SymbolComparisonInfo<'_>> for PySymbolComparisonInfo {
         fn from(value: super::SymbolComparisonInfo) -> Self {
             Self::new(
                 value.symbol.clone(),


### PR DESCRIPTION
## [2.7.2] - 2024-12-15

### Added

- Prebuilt binaries for Python 3.13.

### Changed

- Python 3.9 or later is now required.
  - Bump from Python 3.8 to 3.9.
  - Older versions can't be checked on CI anymore, so I prefer to not claim to
    support something that may have broken without anybody noticing.
  - Nothing really changed. Just the CI tools I was using are refusing to use
    any Python version older than this. Sorry if you were affected by this.
- Use newer pyo3 version.
  - From 0.20 to 0.23.
  - Updated to avoid warnings with newer Rust versions.
  - Fix issues introduced by updating pyo3.
