### PR TITLE
2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Simplify emitted entries by avoiding using quotes as much as possible when
     using the `--emit-categories` flag.
   - Avoid printing the summary table when using the `--emit-categories`.
+  - Allow customizing the output of the summary table a little bit via the
+    Python API.
 
 ## [2.9.1] - 2025-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `objdiff_report`:
+  - Simplify emitted entries by avoiding using quotes as much as possible when
+    using the `--emit-categories` flag.
+  - Avoid printing the summary table when using the `--emit-categories`.
+
 ## [2.9.1] - 2025-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.2] - 2025-05-28
+
 ### Changed
 
 - `objdiff_report`:
@@ -604,6 +606,7 @@ Full changes: <https://github.com/Decompollaborate/mapfile_parser/compare/702a73
 - Initial release
 
 [unreleased]: https://github.com/Decompollaborate/mapfile_parser/compare/master...develop
+[2.9.2]: https://github.com/Decompollaborate/mapfile_parser/compare/2.9.0...2.9.2
 [2.9.1]: https://github.com/Decompollaborate/mapfile_parser/compare/2.9.0...2.9.1
 [2.9.0]: https://github.com/Decompollaborate/mapfile_parser/compare/2.8.1...2.9.0
 [2.8.1]: https://github.com/Decompollaborate/mapfile_parser/compare/2.8.0...2.8.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mapfile_parser"
-version = "2.9.2-dev0"
+version = "2.9.2"
 dependencies = [
  "lazy_static",
  "objdiff-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mapfile_parser"
-version = "2.9.1"
+version = "2.9.2-dev0"
 dependencies = [
  "lazy_static",
  "objdiff-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "mapfile_parser"
-version = "2.9.1"
+version = "2.9.2-dev0"
 edition = "2021"
 rust-version = "1.74.0"
 authors = ["Anghelo Carvajal <angheloalf95@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "mapfile_parser"
-version = "2.9.2-dev0"
+version = "2.9.2"
 edition = "2021"
 rust-version = "1.74.0"
 authors = ["Anghelo Carvajal <angheloalf95@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-mapfile_parser>=2.9.1,<3.0.0
+mapfile_parser>=2.9.2,<3.0.0
 ```
 
 #### Development version
@@ -75,7 +75,7 @@ cargo add mapfile_parser
 Or add the following line manually to your `Cargo.toml` file:
 
 ```toml
-mapfile_parser = "2.9.1"
+mapfile_parser = "2.9.2"
 ```
 
 ## Versioning and changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "2.9.1"
+version = "2.9.2-dev0"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mapfile_parser"
-version = "2.9.2-dev0"
+version = "2.9.2"
 description = "Map file parser library focusing decompilation projects"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__ = (2, 9, 2)
-__version__ = ".".join(map(str, __version_info__)) + "-dev0"
+__version__ = ".".join(map(str, __version_info__)) # + "-dev0"
 __author__ = "Decompollaborate"
 
 from . import utils as utils

--- a/src/mapfile_parser/__init__.py
+++ b/src/mapfile_parser/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (2, 9, 1)
-__version__ = ".".join(map(str, __version_info__)) # + "-dev0"
+__version_info__ = (2, 9, 2)
+__version__ = ".".join(map(str, __version_info__)) + "-dev0"
 __author__ = "Decompollaborate"
 
 from . import utils as utils

--- a/src/mapfile_parser/frontends/objdiff_report.py
+++ b/src/mapfile_parser/frontends/objdiff_report.py
@@ -47,7 +47,7 @@ def doObjdiffReport(
         nonmatchingsPath=nonmatchingsPath,
     )
 
-    if not quiet:
+    if not quiet and not emitCategories:
         report = report_internal.Report.readFile(outputPath)
         if report is None:
             utils.eprint(f"Unable to read back the generated report at {outputPath}")
@@ -241,18 +241,26 @@ tools:
       prefixes_to_trim:
 """, end="")
     for trim in prefixesToTrim:
-        print(f"        - \"{trim}\"")
+        print(f"        - {trim}")
 
     def printCategories(categories: list[Category]):
         for cat in categories:
+            ide = cat.ide
+            name = cat.name
+            if ide[0] in "0123456789":
+                ide = f'"{ide}"'
+            if name[0] in "0123456789":
+                name = f'"{name}"'
             print(f"""\
-        - id: "{cat.ide}"
-          name: "{cat.name}"
+        - id: {ide}
+          name: {name}
           paths:
 """, end="")
             for p in cat.paths:
+                if p[0] in "0123456789":
+                    p = f'"{p}"'
                 print(f"""\
-            - "{p}"
+            - {p}
 """, end="")
 
     print("      categories:")


### PR DESCRIPTION
## [2.9.2] - 2025-05-28

### Changed

- `objdiff_report`:
  - Simplify emitted entries by avoiding using quotes as much as possible when
    using the `--emit-categories` flag.
  - Avoid printing the summary table when using the `--emit-categories`.
  - Allow customizing the output of the summary table a little bit via the
    Python API.
